### PR TITLE
feat(session): add Session page with timer, pause/resume, and sync

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -15,6 +15,7 @@ import { Week } from './pages/Week';
 import { Roadmap } from './pages/Roadmap';
 import { Roadmaps } from './pages/Roadmaps';
 import { Settings } from './pages/Settings';
+import { Session } from './pages/Session';
 import { AppShell } from './components/AppShell';
 import { useEffect } from 'react';
 import { OnboardingGate } from './onboarding/OnboardingGate';
@@ -144,6 +145,7 @@ function AppRoutes() {
         }
       >
         <Route path="/home" element={<Home />} />
+        <Route path="/session" element={<Session />} />
         <Route path="/log" element={<Log />} />
         <Route path="/week" element={<Week />} />
         <Route path="/roadmap" element={<Roadmap />} />

--- a/apps/app/src/components/NavBar.tsx
+++ b/apps/app/src/components/NavBar.tsx
@@ -30,6 +30,15 @@ function RoadmapIcon() {
   );
 }
 
+function SessionIcon() {
+  return (
+    <svg className="icon" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  );
+}
+
 function SettingsIcon() {
   return (
     <svg className="icon" viewBox="0 0 24 24">
@@ -41,6 +50,7 @@ function SettingsIcon() {
 
 const NAV_ITEMS = [
   { to: '/home', label: 'Home', icon: HomeIcon, prefix: '/home' },
+  { to: '/session', label: 'Session', icon: SessionIcon, prefix: '/session' },
   { to: '/week', label: 'Week', icon: WeekIcon, prefix: '/week' },
   { to: '/roadmap', label: 'Roadmap', icon: RoadmapIcon, prefix: '/roadmap' },
   { to: '/settings', label: 'Settings', icon: SettingsIcon, prefix: '/settings' },

--- a/apps/app/src/events/EventStoreProvider.tsx
+++ b/apps/app/src/events/EventStoreProvider.tsx
@@ -32,6 +32,13 @@ function createEventStore(userId: string): EventStore {
     sync_meta: 'key',
     onboardingDraft: 'id',
   });
+  db.version(4).stores({
+    events: '++id, kind, createdAt',
+    sync_queue: '++id, kind, createdAt, retries',
+    sync_meta: 'key',
+    onboardingDraft: 'id',
+    activeSession: 'id',
+  });
   return new EventStore(db);
 }
 

--- a/apps/app/src/lib/DurabilityHooks.test.ts
+++ b/apps/app/src/lib/DurabilityHooks.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DurabilityHooks, type DurabilityEvent } from './DurabilityHooks';
+
+describe('DurabilityHooks', () => {
+  let hooks: DurabilityHooks;
+
+  beforeEach(() => {
+    hooks = new DurabilityHooks(document, window);
+  });
+
+  afterEach(() => {
+    hooks.destroy();
+  });
+
+  it('fires visibilitychange callback when document becomes hidden', () => {
+    const events: DurabilityEvent[] = [];
+    hooks.subscribe(e => events.push(e));
+
+    Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('visibilitychange');
+    expect(events[0].isHidden).toBe(true);
+
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+  });
+
+  it('fires visibilitychange callback when document becomes visible', () => {
+    const events: DurabilityEvent[] = [];
+    hooks.subscribe(e => events.push(e));
+
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('visibilitychange');
+    expect(events[0].isHidden).toBe(false);
+  });
+
+  it('computes hidden duration on return to visible', () => {
+    vi.useFakeTimers();
+    const events: DurabilityEvent[] = [];
+    hooks.subscribe(e => events.push(e));
+
+    Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    vi.advanceTimersByTime(3000);
+
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(events).toHaveLength(2);
+    expect(events[1].hiddenDurationMs).toBe(3000);
+    expect(events[1].isHidden).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it('fires pagehide callback', () => {
+    const events: DurabilityEvent[] = [];
+    hooks.subscribe(e => events.push(e));
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('pagehide');
+    expect(events[0].isHidden).toBe(true);
+  });
+
+  it('fires beforeunload callback', () => {
+    const events: DurabilityEvent[] = [];
+    hooks.subscribe(e => events.push(e));
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('beforeunload');
+    expect(events[0].isHidden).toBe(true);
+  });
+
+  it('calls multiple subscribers for the same event', () => {
+    const events1: DurabilityEvent[] = [];
+    const events2: DurabilityEvent[] = [];
+    hooks.subscribe(e => events1.push(e));
+    hooks.subscribe(e => events2.push(e));
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(events1).toHaveLength(1);
+    expect(events2).toHaveLength(1);
+  });
+
+  it('unsubscribe stops delivery to that callback', () => {
+    const events: DurabilityEvent[] = [];
+    const unsub = hooks.subscribe(e => events.push(e));
+
+    window.dispatchEvent(new Event('pagehide'));
+    expect(events).toHaveLength(1);
+
+    unsub();
+
+    window.dispatchEvent(new Event('pagehide'));
+    expect(events).toHaveLength(1);
+  });
+
+  it('destroy removes all listeners', () => {
+    const events: DurabilityEvent[] = [];
+    hooks.subscribe(e => events.push(e));
+
+    hooks.destroy();
+
+    window.dispatchEvent(new Event('pagehide'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('one subscriber throwing does not break others', () => {
+    const events: DurabilityEvent[] = [];
+    hooks.subscribe(() => { throw new Error('boom'); });
+    hooks.subscribe(e => events.push(e));
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(events).toHaveLength(1);
+  });
+});

--- a/apps/app/src/lib/DurabilityHooks.ts
+++ b/apps/app/src/lib/DurabilityHooks.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared browser lifecycle event handler.
+ *
+ * Registers visibilitychange, pagehide, and beforeunload listeners once
+ * and dispatches to multiple subscribers. Used by SyncEngine (flush pending
+ * events) and SessionLifecycle (persist active session state).
+ */
+
+export type DurabilityEventType = 'visibilitychange' | 'pagehide' | 'beforeunload';
+
+export interface DurabilityEvent {
+  type: DurabilityEventType;
+  /** True when the page is hidden / being unloaded */
+  isHidden: boolean;
+  /** For visibilitychange: ms the page was hidden (0 on hide, computed on show) */
+  hiddenDurationMs: number;
+}
+
+export type DurabilityCallback = (event: DurabilityEvent) => void;
+
+export class DurabilityHooks {
+  private readonly subscribers = new Set<DurabilityCallback>();
+  private hiddenSince = 0;
+  private readonly doc: Document;
+  private readonly win: Window;
+  private boundVisibility: (() => void) | null = null;
+  private boundPageHide: (() => void) | null = null;
+  private boundBeforeUnload: (() => void) | null = null;
+
+  constructor(doc: Document = document, win: Window = window) {
+    this.doc = doc;
+    this.win = win;
+    this.attach();
+  }
+
+  subscribe(callback: DurabilityCallback): () => void {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  destroy(): void {
+    this.detach();
+    this.subscribers.clear();
+  }
+
+  private attach(): void {
+    this.boundVisibility = () => this.handleVisibilityChange();
+    this.boundPageHide = () => this.handlePageHide();
+    this.boundBeforeUnload = () => this.handleBeforeUnload();
+
+    this.doc.addEventListener('visibilitychange', this.boundVisibility);
+    this.win.addEventListener('pagehide', this.boundPageHide);
+    this.win.addEventListener('beforeunload', this.boundBeforeUnload);
+  }
+
+  private detach(): void {
+    if (this.boundVisibility) {
+      this.doc.removeEventListener('visibilitychange', this.boundVisibility);
+    }
+    if (this.boundPageHide) {
+      this.win.removeEventListener('pagehide', this.boundPageHide);
+    }
+    if (this.boundBeforeUnload) {
+      this.win.removeEventListener('beforeunload', this.boundBeforeUnload);
+    }
+  }
+
+  private handleVisibilityChange(): void {
+    const isHidden = this.doc.hidden;
+    let hiddenDurationMs = 0;
+
+    if (isHidden) {
+      this.hiddenSince = Date.now();
+    } else {
+      hiddenDurationMs = this.hiddenSince > 0 ? Date.now() - this.hiddenSince : 0;
+      this.hiddenSince = 0;
+    }
+
+    this.dispatch({ type: 'visibilitychange', isHidden, hiddenDurationMs });
+  }
+
+  private handlePageHide(): void {
+    this.dispatch({ type: 'pagehide', isHidden: true, hiddenDurationMs: 0 });
+  }
+
+  private handleBeforeUnload(): void {
+    this.dispatch({ type: 'beforeunload', isHidden: true, hiddenDurationMs: 0 });
+  }
+
+  private dispatch(event: DurabilityEvent): void {
+    for (const cb of this.subscribers) {
+      try {
+        cb(event);
+      } catch {
+        // Subscribers should not throw, but never let one break others
+      }
+    }
+  }
+}

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useAuth } from '../auth/useAuth';
 import { useEventStore } from '../events/useEventStore';
 import { totalMinutesLogged, getProjectedFinish, getUpNextSlot } from '../events/ProgressEngine';
@@ -5,10 +6,12 @@ import type { Event } from '../events/EventStore';
 import { useLiveQuery } from 'dexie-react-hooks';
 import Card from '../components/Card';
 import Button from '../components/Button';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { ROLE_TO_LABEL } from '@study-tracker/progress-engine';
 import type { Slot } from '@study-tracker/progress-engine';
 import type { RoadmapCreatedPayload } from '../sync/types';
+import type { ActiveSessionRecord, SessionSlotData } from '../session/types';
+import { AbandonedSessionBanner } from '../session/components/AbandonedSessionBanner';
 import { format, isToday, isTomorrow, differenceInCalendarDays } from 'date-fns';
 
 function formatMinutesToHoursAndMinutes(totalMinutes: number): string {
@@ -48,8 +51,19 @@ function findRoadmap(events: Array<{ kind: string; payload: Record<string, unkno
 export function Home() {
   const { user, signOut } = useAuth();
   const eventStore = useEventStore();
+  const navigate = useNavigate();
+  const [bannerDismissed, setBannerDismissed] = useState(false);
 
   const events = useLiveQuery(() => eventStore.getAll()) ?? [];
+
+  const activeSession = useLiveQuery(
+    () => eventStore.table('activeSession').get(1) as Promise<ActiveSessionRecord | undefined>,
+    [],
+  );
+
+  const abandonedEvent = events
+    .filter(e => e.kind === 'SessionAbandoned')
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
   const sessionEvents: Event[] = events
     .filter((e): e is Event => e.kind === 'SessionLogged')
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -78,8 +92,28 @@ export function Home() {
           Here's how your study time adds up
         </p>
 
+        {abandonedEvent && !bannerDismissed && (
+          <AbandonedSessionBanner
+            activeMinutes={(abandonedEvent.payload.activeMinutesAtAbandon as number) ?? 0}
+            onDismiss={() => setBannerDismissed(true)}
+          />
+        )}
+
         {roadmapPayload && (
-          upNextSlot ? (
+          activeSession ? (
+            <Card variant="inverted" style={{ marginBottom: '1.5rem' }}>
+              <div className="card-eyebrow">
+                In progress · started {new Date(activeSession.startedAt).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+              </div>
+              <div className="card-title">{activeSession.sessionTitle}</div>
+              <div className="card-meta">
+                ~{activeSession.plannedMinutes} min planned · {activeSession.status === 'paused' ? 'paused' : 'running'}
+              </div>
+              <div className="upnext-actions">
+                <Link to="/session" className="btn btn-accent">Continue session</Link>
+              </div>
+            </Card>
+          ) : upNextSlot ? (
             <Card variant="inverted" style={{ marginBottom: '1.5rem' }}>
               <div className="card-eyebrow">Up next · {formatDateNice(upNextSlot.date)}</div>
               <div className="card-title">{upNextSlot.sessionTitle || 'Study session'}</div>
@@ -92,7 +126,25 @@ export function Home() {
                 ~{upNextSlot.plannedMinutes} min planned
               </div>
               <div className="upnext-actions">
-                <Link to="/log" className="btn btn-accent">Log session</Link>
+                <button
+                  className="btn btn-accent"
+                  onClick={() => {
+                    const materials = events.filter(e => e.kind === 'MaterialAdded');
+                    const material = materials.find(m => (m.payload.materialId as string) === upNextSlot.candidateMaterialIds[0]);
+                    const sessionSlot: SessionSlotData = {
+                      materialId: upNextSlot.candidateMaterialIds[0] ?? '',
+                      sessionTitle: upNextSlot.sessionTitle ?? 'Study session',
+                      slotDate: upNextSlot.date,
+                      weekIndex: upNextSlot.weekIndex,
+                      plannedMinutes: upNextSlot.plannedMinutes,
+                      materialUrl: material?.payload.url as string | undefined,
+                      role: upNextSlot.role as SessionSlotData['role'],
+                    };
+                    navigate('/session', { state: sessionSlot });
+                  }}
+                >
+                  Start session
+                </button>
               </div>
             </Card>
           ) : (

--- a/apps/app/src/pages/Session.tsx
+++ b/apps/app/src/pages/Session.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useLocation, useNavigate, Link } from 'react-router-dom';
+import { useEventStore } from '../events/useEventStore';
+import { DurabilityHooks } from '../lib/DurabilityHooks';
+import { SessionLifecycle } from '../session/SessionLifecycle';
+import { DEFAULT_POMODORO_CONFIG } from '../session/types';
+import type { SessionState, SessionSlotData, WalkAwayResolution, RecoveryResolution } from '../session/types';
+import type { PomodoroPhase } from '../session/pomodoro';
+import {
+  PulseDot,
+  SessionEyebrow,
+  getEyebrowColorClass,
+  SessionTitle,
+  SessionSubtitle,
+  TimerDisplay,
+  PomodoroIndicator,
+  PlannedEndLine,
+  OpenMaterialButton,
+  MaterialStrip,
+  EndSessionButton,
+  ComeBackLaterButton,
+  PauseResumeButton,
+  SessionFrame,
+  WalkAwayDialog,
+  RecoveryDialog,
+} from '../session/components';
+import '../session/session.css';
+
+export function Session() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const eventStore = useEventStore();
+  const slotData = location.state as SessionSlotData | null;
+
+  const lcRef = useRef<SessionLifecycle | null>(null);
+  const durabilityRef = useRef<DurabilityHooks | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  const [sessionState, setSessionState] = useState<SessionState>('idle');
+  const [elapsedActiveMs, setElapsedActiveMs] = useState(0);
+  const [, setElapsedWallClockMs] = useState(0);
+  const [pomodoroPhase, setPomodoroPhase] = useState<PomodoroPhase>({ phase: 'none', current: 0, total: 0, remainingMs: 0 });
+  const [initialized, setInitialized] = useState(false);
+
+  // Initialize lifecycle
+  useEffect(() => {
+    const durability = new DurabilityHooks();
+    durabilityRef.current = durability;
+
+    const lc = new SessionLifecycle({
+      eventStore,
+      durabilityHooks: durability,
+      pomodoroConfig: DEFAULT_POMODORO_CONFIG,
+      audioContext: null, // Created on user gesture (start)
+    });
+
+    lcRef.current = lc;
+    lc.subscribe(setSessionState);
+
+    const init = async () => {
+      const state = await lc.initialize();
+
+      if (state === 'idle' && slotData) {
+        try {
+          audioCtxRef.current = new AudioContext();
+        } catch {
+          // AudioContext not available
+        }
+        await lc.start(slotData);
+      }
+
+      setSessionState(lc.getState());
+      setInitialized(true);
+    };
+
+    init();
+
+    return () => {
+      lc.destroy();
+      durability.destroy();
+    };
+  }, [eventStore, slotData]);
+
+  // Timer tick interval
+  useEffect(() => {
+    if (sessionState !== 'active' && sessionState !== 'walk_away') return;
+
+    const interval = setInterval(() => {
+      const lc = lcRef.current;
+      if (!lc) return;
+
+      lc.tick();
+      setElapsedActiveMs(lc.getElapsedActiveMs());
+      setElapsedWallClockMs(lc.getElapsedWallClockMs());
+      setPomodoroPhase(lc.getPomodoroPhase());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [sessionState]);
+
+  // Update derived state when paused (no tick running)
+  useEffect(() => {
+    const lc = lcRef.current;
+    if (!lc || sessionState === 'idle') return;
+    setElapsedActiveMs(lc.getElapsedActiveMs());
+    setElapsedWallClockMs(lc.getElapsedWallClockMs());
+    setPomodoroPhase(lc.getPomodoroPhase());
+  }, [sessionState]);
+
+  const handlePauseResume = useCallback(async () => {
+    const lc = lcRef.current;
+    if (!lc) return;
+
+    if (sessionState === 'paused') {
+      await lc.resume();
+    } else {
+      await lc.pause();
+    }
+  }, [sessionState]);
+
+  const handleEnd = useCallback(async () => {
+    const lc = lcRef.current;
+    if (!lc) return;
+    await lc.end();
+    navigate('/home');
+  }, [navigate]);
+
+  const handleComeBackLater = useCallback(async () => {
+    const lc = lcRef.current;
+    if (!lc) return;
+    await lc.pause();
+    navigate('/home');
+  }, [navigate]);
+
+  const handleWalkAwayResolve = useCallback(async (resolution: WalkAwayResolution) => {
+    const lc = lcRef.current;
+    if (!lc) return;
+    await lc.resolveWalkAway(resolution);
+    navigate('/home');
+  }, [navigate]);
+
+  const handleRecoveryResolve = useCallback(async (resolution: RecoveryResolution) => {
+    const lc = lcRef.current;
+    if (!lc) return;
+    await lc.resolveRecovery(resolution);
+    if (resolution === 'end_now') {
+      navigate('/home');
+    }
+  }, [navigate]);
+
+  if (!initialized) {
+    return (
+      <div className="session-layout session-layout-centered">
+        <p className="t-body" style={{ color: 'var(--text-secondary)', textAlign: 'center' }}>
+          Loading...
+        </p>
+      </div>
+    );
+  }
+
+  // No active session and no slot data to start one
+  if (sessionState === 'idle') {
+    return (
+      <div className="session-empty">
+        <p className="t-body">No active session.</p>
+        <p>Start one from your home screen.</p>
+        <Link to="/home" className="btn btn-secondary">Go to Home</Link>
+      </div>
+    );
+  }
+
+  const record = lcRef.current?.getRecord();
+  if (!record) return null;
+
+  const isOverrun = (lcRef.current?.isOverrun()) ?? false;
+  const isBreak = pomodoroPhase.phase === 'break';
+  const isPaused = sessionState === 'paused';
+  const overrunMinutes = isOverrun
+    ? Math.round((elapsedActiveMs - record.plannedMinutes * 60_000) / 60_000)
+    : 0;
+
+  const plannedEndTime = new Date(new Date(record.startedAt).getTime() + record.plannedMinutes * 60_000);
+  const startedAtLabel = new Date(record.startedAt).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  const materialMeta = record.materialUrl ? 'MANUAL · LINKED' : 'MANUAL · NO EMBED';
+
+  return (
+    <>
+      <div className="session-layout session-layout-centered">
+        <div className="session-top-bar">
+          <PauseResumeButton isPaused={isPaused} onToggle={handlePauseResume} />
+        </div>
+
+        <SessionFrame overrun={isOverrun} isBreak={isBreak} isPaused={isPaused}>
+          <div className={`session-eyebrow-row ${getEyebrowColorClass(sessionState, overrunMinutes, isBreak)}`}>
+            <PulseDot state={sessionState} />
+            <SessionEyebrow
+              state={sessionState}
+              weekIndex={record.weekIndex}
+              overrunMinutes={overrunMinutes}
+              isBreak={isBreak}
+            />
+          </div>
+
+          <SessionTitle title={record.sessionTitle} />
+          <SessionSubtitle subtitle={record.materialUrl ? 'Linked material' : 'Manual · pen and paper'} />
+
+          <div className="session-timer-display">
+            <TimerDisplay elapsedMs={elapsedActiveMs} overrun={isOverrun} large />
+            <PomodoroIndicator phase={pomodoroPhase} />
+            <PlannedEndLine
+              plannedMinutes={record.plannedMinutes}
+              endsAt={plannedEndTime}
+              overrun={isOverrun}
+            />
+          </div>
+
+          {record.materialUrl && (
+            <OpenMaterialButton url={record.materialUrl} />
+          )}
+
+          <MaterialStrip
+            title={record.sessionTitle}
+            meta={materialMeta}
+          />
+        </SessionFrame>
+
+        <div className="session-actions">
+          <EndSessionButton onEnd={handleEnd} />
+          {!isPaused && (
+            <ComeBackLaterButton onComeBackLater={handleComeBackLater} />
+          )}
+        </div>
+
+        {/* Desktop floating End button */}
+      </div>
+
+      {sessionState === 'walk_away' && (
+        <WalkAwayDialog
+          materialTitle={record.sessionTitle}
+          elapsedMinutes={Math.round(elapsedActiveMs / 60_000)}
+          startedAtLabel={startedAtLabel}
+          plannedMinutes={record.plannedMinutes}
+          onResolve={handleWalkAwayResolve}
+        />
+      )}
+
+      {sessionState === 'recovery' && (
+        <RecoveryDialog
+          materialTitle={record.sessionTitle}
+          elapsedMinutes={Math.round(elapsedActiveMs / 60_000)}
+          awayMinutes={0}
+          onResolve={handleRecoveryResolve}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/app/src/session/SessionLifecycle.test.ts
+++ b/apps/app/src/session/SessionLifecycle.test.ts
@@ -1,0 +1,605 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Dexie from 'dexie';
+import { EventStore } from '../events/EventStore';
+import { DurabilityHooks } from '../lib/DurabilityHooks';
+import { SessionLifecycle, type SessionLifecycleDeps } from './SessionLifecycle';
+import type { ActiveSessionRecord, SessionSlotData } from './types';
+import { SESSION_EVENT_KINDS, DEFAULT_POMODORO_CONFIG } from './types';
+
+const DB_NAME = 'StudyTrackerTest-SessionLifecycle';
+
+function createTestDb(): { db: Dexie; eventStore: EventStore } {
+  const db = new Dexie(DB_NAME);
+  db.version(1).stores({
+    events: '++id, kind, createdAt',
+    activeSession: 'id',
+  });
+  return { db, eventStore: new EventStore(db) };
+}
+
+const slotData: SessionSlotData = {
+  materialId: 'mat-1',
+  sessionTitle: 'Practice problems · ch. 5',
+  slotDate: '2026-04-29',
+  weekIndex: 2,
+  plannedMinutes: 60,
+  materialUrl: 'https://drive.google.com/some-pdf',
+};
+
+describe('SessionLifecycle', () => {
+  let db: Dexie;
+  let eventStore: EventStore;
+  let durability: DurabilityHooks;
+  let currentTime: Date;
+
+  function makeNow() {
+    return () => currentTime;
+  }
+
+  function makeDeps(overrides?: Partial<SessionLifecycleDeps>): SessionLifecycleDeps {
+    return {
+      eventStore,
+      durabilityHooks: durability,
+      now: makeNow(),
+      pomodoroConfig: DEFAULT_POMODORO_CONFIG,
+      audioContext: null,
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const created = createTestDb();
+    db = created.db;
+    eventStore = created.eventStore;
+    durability = new DurabilityHooks(document, window);
+    currentTime = new Date('2026-04-29T09:00:00Z');
+    await db.open();
+    await db.table('events').clear();
+    await db.table('activeSession').clear();
+  });
+
+  afterEach(async () => {
+    durability.destroy();
+    db.close();
+  });
+
+  // -----------------------------------------------------------------------
+  // Start → End happy path
+  // -----------------------------------------------------------------------
+
+  describe('start and end', () => {
+    it('starts a session and transitions to active', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      expect(lc.getState()).toBe('active');
+      expect(lc.getRecord()?.sessionId).toBeTruthy();
+      expect(lc.getRecord()?.materialId).toBe('mat-1');
+
+      const events = await eventStore.getAll();
+      expect(events.filter(e => e.kind === SESSION_EVENT_KINDS.STARTED)).toHaveLength(1);
+
+      lc.destroy();
+    });
+
+    it('ending a session logs it and returns to idle', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:45:00Z'); // 45 min later
+      await lc.end();
+
+      expect(lc.getState()).toBe('idle');
+      expect(lc.getRecord()).toBeNull();
+
+      const events = await eventStore.getAll();
+      const logged = events.find(e => e.kind === SESSION_EVENT_KINDS.LOGGED);
+      expect(logged).toBeTruthy();
+      expect(logged!.payload.duration).toBe(45);
+      expect(logged!.payload.source).toBe('active');
+      expect(logged!.payload.resolution).toBe('completed');
+
+      lc.destroy();
+    });
+
+    it('cannot start a session when one is already active', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      await expect(lc.start(slotData)).rejects.toThrow('Cannot start session');
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Pause / Resume
+  // -----------------------------------------------------------------------
+
+  describe('pause and resume', () => {
+    it('pausing stops the active time clock', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:30:00Z'); // +30 min
+      await lc.pause();
+      expect(lc.getState()).toBe('paused');
+
+      currentTime = new Date('2026-04-29T10:00:00Z'); // +30 min paused
+      // Active time should still be 30 min, not 60
+      expect(Math.round(lc.getElapsedActiveMs() / 60_000)).toBe(30);
+
+      const events = await eventStore.getAll();
+      const paused = events.find(e => e.kind === SESSION_EVENT_KINDS.PAUSED);
+      expect(paused).toBeTruthy();
+      expect(paused!.payload.elapsedActiveMinutes).toBe(30);
+
+      lc.destroy();
+    });
+
+    it('resume restores active state and time tracking', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:30:00Z');
+      await lc.pause();
+
+      currentTime = new Date('2026-04-29T10:00:00Z');
+      await lc.resume();
+      expect(lc.getState()).toBe('active');
+
+      currentTime = new Date('2026-04-29T10:15:00Z'); // +15 min after resume
+      expect(Math.round(lc.getElapsedActiveMs() / 60_000)).toBe(45); // 30 + 15
+
+      const events = await eventStore.getAll();
+      expect(events.filter(e => e.kind === SESSION_EVENT_KINDS.RESUMED)).toHaveLength(1);
+
+      lc.destroy();
+    });
+
+    it('ending during pause logs the accumulated active time', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:35:00Z');
+      await lc.pause();
+
+      currentTime = new Date('2026-04-29T11:00:00Z'); // long pause
+      await lc.end();
+
+      expect(lc.getState()).toBe('idle');
+      const events = await eventStore.getAll();
+      const logged = events.find(e => e.kind === SESSION_EVENT_KINDS.LOGGED);
+      expect(logged!.payload.duration).toBe(35);
+      expect(logged!.payload.pauseCount).toBe(1);
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Walk-away detection
+  // -----------------------------------------------------------------------
+
+  describe('walk-away', () => {
+    it('tick transitions to walk_away when 10 min past planned end', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData); // 60 min planned
+
+      currentTime = new Date('2026-04-29T10:09:00Z'); // 69 min, not yet
+      expect(lc.tick()).toBe('active');
+
+      currentTime = new Date('2026-04-29T10:11:00Z'); // 71 min, over threshold
+      expect(lc.tick()).toBe('walk_away');
+      expect(lc.getState()).toBe('walk_away');
+
+      lc.destroy();
+    });
+
+    it('resolveWalkAway log_all logs full elapsed time', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T10:30:00Z'); // 90 min elapsed
+      lc.tick();
+
+      await lc.resolveWalkAway('log_all');
+      expect(lc.getState()).toBe('idle');
+
+      const logged = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.LOGGED);
+      expect(logged!.payload.duration).toBe(90);
+      expect(logged!.payload.resolution).toBe('completed');
+
+      lc.destroy();
+    });
+
+    it('resolveWalkAway trim logs planned duration', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T10:30:00Z');
+      lc.tick();
+
+      await lc.resolveWalkAway('trim');
+      const logged = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.LOGGED);
+      expect(logged!.payload.duration).toBe(60); // planned minutes
+      expect(logged!.payload.resolution).toBe('trimmed');
+
+      lc.destroy();
+    });
+
+    it('resolveWalkAway discard abandons the session', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T10:30:00Z');
+      lc.tick();
+
+      await lc.resolveWalkAway('discard');
+      expect(lc.getState()).toBe('idle');
+
+      const abandoned = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.ABANDONED);
+      expect(abandoned!.payload.reason).toBe('discarded');
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Recovery (tab-close-and-reopen)
+  // -----------------------------------------------------------------------
+
+  describe('recovery', () => {
+    async function setupPersistedSession() {
+      const record: ActiveSessionRecord = {
+        id: 1,
+        sessionId: 'session-123',
+        materialId: 'mat-1',
+        sessionTitle: 'Practice problems',
+        slotDate: '2026-04-29',
+        weekIndex: 2,
+        plannedMinutes: 60,
+        startedAt: '2026-04-29T09:00:00Z',
+        status: 'active',
+        pauseIntervals: [],
+        pomodoroConfig: DEFAULT_POMODORO_CONFIG,
+      };
+      await eventStore.table('activeSession').put(record);
+    }
+
+    it('silent resume when hidden < 5 min', async () => {
+      await setupPersistedSession();
+      currentTime = new Date('2026-04-29T09:30:00Z');
+
+      const lc = new SessionLifecycle(makeDeps());
+      const state = await lc.initializeWithRecovery(3 * 60_000); // 3 min away
+
+      expect(state).toBe('active');
+      lc.destroy();
+    });
+
+    it('recovery dialog when hidden > 5 min', async () => {
+      await setupPersistedSession();
+      currentTime = new Date('2026-04-29T09:30:00Z');
+
+      const lc = new SessionLifecycle(makeDeps());
+      const state = await lc.initializeWithRecovery(8 * 60_000); // 8 min away
+
+      expect(state).toBe('recovery');
+      lc.destroy();
+    });
+
+    it('resolveRecovery keep_going resumes to active', async () => {
+      await setupPersistedSession();
+      currentTime = new Date('2026-04-29T09:30:00Z');
+
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.initializeWithRecovery(8 * 60_000);
+
+      await lc.resolveRecovery('keep_going');
+      expect(lc.getState()).toBe('active');
+
+      lc.destroy();
+    });
+
+    it('resolveRecovery end_now logs active time', async () => {
+      await setupPersistedSession();
+      currentTime = new Date('2026-04-29T09:30:00Z');
+
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.initializeWithRecovery(8 * 60_000);
+
+      await lc.resolveRecovery('end_now');
+      expect(lc.getState()).toBe('idle');
+
+      const logged = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.LOGGED);
+      expect(logged!.payload.duration).toBe(30);
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Stale session abandonment
+  // -----------------------------------------------------------------------
+
+  describe('stale detection', () => {
+    it('abandons active session after 6 hours', async () => {
+      const record: ActiveSessionRecord = {
+        id: 1,
+        sessionId: 'session-stale',
+        materialId: 'mat-1',
+        sessionTitle: 'Stale session',
+        slotDate: '2026-04-29',
+        weekIndex: 0,
+        plannedMinutes: 60,
+        startedAt: '2026-04-29T09:00:00Z',
+        status: 'active',
+        pauseIntervals: [],
+        pomodoroConfig: DEFAULT_POMODORO_CONFIG,
+      };
+      await eventStore.table('activeSession').put(record);
+
+      currentTime = new Date('2026-04-29T15:30:00Z'); // 6.5h later
+
+      const lc = new SessionLifecycle(makeDeps());
+      const state = await lc.initialize();
+
+      expect(state).toBe('idle');
+      const abandoned = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.ABANDONED);
+      expect(abandoned!.payload.reason).toBe('stale_6h');
+
+      lc.destroy();
+    });
+
+    it('abandons active session crossing midnight', async () => {
+      const record: ActiveSessionRecord = {
+        id: 1,
+        sessionId: 'session-midnight',
+        materialId: 'mat-1',
+        sessionTitle: 'Midnight session',
+        slotDate: '2026-04-29',
+        weekIndex: 0,
+        plannedMinutes: 60,
+        startedAt: '2026-04-29T23:30:00Z',
+        status: 'active',
+        pauseIntervals: [],
+        pomodoroConfig: DEFAULT_POMODORO_CONFIG,
+      };
+      await eventStore.table('activeSession').put(record);
+
+      currentTime = new Date('2026-04-30T07:00:00Z'); // next day
+
+      const lc = new SessionLifecycle(makeDeps());
+      const state = await lc.initialize();
+
+      expect(state).toBe('idle');
+      const abandoned = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.ABANDONED);
+      expect(abandoned!.payload.reason).toBe('stale_midnight');
+
+      lc.destroy();
+    });
+
+    it('abandons paused session after 12h continuous pause', async () => {
+      const record: ActiveSessionRecord = {
+        id: 1,
+        sessionId: 'session-paused-stale',
+        materialId: 'mat-1',
+        sessionTitle: 'Paused stale',
+        slotDate: '2026-04-28',
+        weekIndex: 0,
+        plannedMinutes: 60,
+        startedAt: '2026-04-28T09:00:00Z',
+        status: 'paused',
+        pauseIntervals: [{ pausedAt: '2026-04-28T09:40:00Z' }],
+        pomodoroConfig: DEFAULT_POMODORO_CONFIG,
+      };
+      await eventStore.table('activeSession').put(record);
+
+      currentTime = new Date('2026-04-29T08:00:00Z'); // ~22h paused
+
+      const lc = new SessionLifecycle(makeDeps());
+      const state = await lc.initialize();
+
+      expect(state).toBe('idle');
+      const abandoned = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.ABANDONED);
+      expect(abandoned!.payload.reason).toBe('stale_12h_paused');
+      expect(abandoned!.payload.activeMinutesAtAbandon).toBe(40);
+
+      lc.destroy();
+    });
+
+    it('paused session under 12h stays paused', async () => {
+      const record: ActiveSessionRecord = {
+        id: 1,
+        sessionId: 'session-paused-ok',
+        materialId: 'mat-1',
+        sessionTitle: 'Paused OK',
+        slotDate: '2026-04-29',
+        weekIndex: 0,
+        plannedMinutes: 60,
+        startedAt: '2026-04-29T09:00:00Z',
+        status: 'paused',
+        pauseIntervals: [{ pausedAt: '2026-04-29T09:40:00Z' }],
+        pomodoroConfig: DEFAULT_POMODORO_CONFIG,
+      };
+      await eventStore.table('activeSession').put(record);
+
+      currentTime = new Date('2026-04-29T18:00:00Z'); // ~8h paused
+
+      const lc = new SessionLifecycle(makeDeps());
+      const state = await lc.initialize();
+
+      expect(state).toBe('paused');
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DurabilityHooks persistence
+  // -----------------------------------------------------------------------
+
+  describe('durability', () => {
+    it('persists to Dexie on pagehide', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:20:00Z');
+
+      window.dispatchEvent(new Event('pagehide'));
+
+      // Give the async persist a tick
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const saved = await eventStore.table('activeSession').get(1);
+      expect(saved).toBeTruthy();
+      expect(saved.sessionId).toBe(lc.getRecord()!.sessionId);
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Pomodoro
+  // -----------------------------------------------------------------------
+
+  describe('pomodoro', () => {
+    it('returns none for slots shorter than work interval', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start({ ...slotData, plannedMinutes: 30 });
+
+      const phase = lc.getPomodoroPhase();
+      expect(phase.phase).toBe('none');
+
+      lc.destroy();
+    });
+
+    it('returns work phase during first work block', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData); // 60 min
+
+      currentTime = new Date('2026-04-29T09:25:00Z');
+      const phase = lc.getPomodoroPhase();
+      expect(phase.phase).toBe('work');
+      expect(phase.current).toBe(1);
+      expect(phase.total).toBe(1);
+
+      lc.destroy();
+    });
+
+    it('returns break phase after work block', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:52:00Z'); // 52 min = in break
+      const phase = lc.getPomodoroPhase();
+      expect(phase.phase).toBe('break');
+
+      lc.destroy();
+    });
+
+    it('returns overtime past planned end', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T10:05:00Z'); // 65 min
+      const phase = lc.getPomodoroPhase();
+      expect(phase.phase).toBe('overtime');
+
+      lc.destroy();
+    });
+
+    it('wall-clock based: Pomodoro advances during pause', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData); // 60 min, work = 50, break = 10
+
+      currentTime = new Date('2026-04-29T09:30:00Z'); // 30 min
+      await lc.pause();
+
+      // Still paused at 55 min wall-clock — should be in break phase
+      currentTime = new Date('2026-04-29T09:55:00Z');
+      const phase = lc.getPomodoroPhase();
+      expect(phase.phase).toBe('break');
+
+      lc.destroy();
+    });
+
+    it('ending mid-pomodoro logs partial time', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:25:00Z'); // 25 min into 50 min work
+      await lc.end();
+
+      const logged = (await eventStore.getAll()).find(e => e.kind === SESSION_EVENT_KINDS.LOGGED);
+      expect(logged!.payload.duration).toBe(25);
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // State listener
+  // -----------------------------------------------------------------------
+
+  describe('listeners', () => {
+    it('notifies listeners on state changes', async () => {
+      const states: string[] = [];
+      const lc = new SessionLifecycle(makeDeps());
+      lc.subscribe(s => states.push(s));
+
+      await lc.start(slotData);
+      expect(states).toContain('active');
+
+      currentTime = new Date('2026-04-29T09:30:00Z');
+      await lc.pause();
+      expect(states).toContain('paused');
+
+      lc.destroy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // SessionLogged payload shape
+  // -----------------------------------------------------------------------
+
+  describe('SessionLogged payload', () => {
+    it('contains all expected fields', async () => {
+      const lc = new SessionLifecycle(makeDeps());
+      await lc.start(slotData);
+
+      currentTime = new Date('2026-04-29T09:20:00Z');
+      await lc.pause();
+
+      currentTime = new Date('2026-04-29T09:30:00Z');
+      await lc.resume();
+
+      currentTime = new Date('2026-04-29T09:50:00Z');
+      await lc.end();
+
+      const events = await eventStore.getAll();
+      const logged = events.find(e => e.kind === SESSION_EVENT_KINDS.LOGGED)!;
+      const p = logged.payload;
+
+      expect(p.sessionId).toBeTruthy();
+      expect(p.materialId).toBe('mat-1');
+      expect(p.sessionTitle).toBe('Practice problems · ch. 5');
+      expect(p.slotDate).toBe('2026-04-29');
+      expect(p.weekIndex).toBe(2);
+      expect(p.plannedMinutes).toBe(60);
+      expect(p.startedAt).toBeTruthy();
+      expect(p.endedAt).toBeTruthy();
+      expect(p.activeMinutes).toBe(40); // 20 + 20, minus 10 paused
+      expect(p.pauseCount).toBe(1);
+      expect(p.totalPauseMinutes).toBe(10);
+      expect(p.source).toBe('active');
+      expect(p.resolution).toBe('completed');
+      expect(p.duration).toBe(40);
+      expect(p.description).toBe('Practice problems · ch. 5');
+      expect(p.date).toBe('2026-04-29');
+
+      lc.destroy();
+    });
+  });
+});

--- a/apps/app/src/session/SessionLifecycle.ts
+++ b/apps/app/src/session/SessionLifecycle.ts
@@ -1,0 +1,490 @@
+import type { EventStore } from '../events/EventStore';
+import type { DurabilityHooks } from '../lib/DurabilityHooks';
+import type {
+  SessionState,
+  ActiveSessionRecord,
+  PomodoroConfig,
+  SessionStartedPayload,
+  SessionPausedPayload,
+  SessionResumedPayload,
+  SessionLoggedPayload,
+  SessionAbandonedPayload,
+  WalkAwayResolution,
+  RecoveryResolution,
+  SessionSlotData,
+} from './types';
+import { SESSION_EVENT_KINDS, DEFAULT_POMODORO_CONFIG } from './types';
+import { getPomodoroPhase, type PomodoroPhase } from './pomodoro';
+import { createChime } from './chime';
+
+const WALK_AWAY_THRESHOLD_MS = 10 * 60_000; // 10 min past planned end
+const RECOVERY_THRESHOLD_MS = 5 * 60_000;   // 5 min away = silent resume
+const STALE_ACTIVE_MS = 6 * 60 * 60_000;    // 6 hours
+const STALE_PAUSED_MS = 12 * 60 * 60_000;   // 12 hours continuous pause
+
+export type SessionLifecycleListener = (state: SessionState) => void;
+
+export interface SessionLifecycleDeps {
+  eventStore: EventStore;
+  durabilityHooks: DurabilityHooks;
+  now?: () => Date;
+  pomodoroConfig?: PomodoroConfig;
+  audioContext?: AudioContext | null;
+}
+
+export class SessionLifecycle {
+  private readonly eventStore: EventStore;
+  private readonly durabilityHooks: DurabilityHooks;
+  private readonly now: () => Date;
+  private readonly pomodoroConfig: PomodoroConfig;
+
+  private state: SessionState = 'idle';
+  private record: ActiveSessionRecord | null = null;
+  private listeners = new Set<SessionLifecycleListener>();
+  private unsubDurability: (() => void) | null = null;
+  private chime: ReturnType<typeof createChime> | null = null;
+  private lastPomodoroPhase: 'work' | 'break' | 'none' = 'none';
+
+  constructor(deps: SessionLifecycleDeps) {
+    this.eventStore = deps.eventStore;
+    this.durabilityHooks = deps.durabilityHooks;
+    this.now = deps.now ?? (() => new Date());
+    this.pomodoroConfig = deps.pomodoroConfig ?? DEFAULT_POMODORO_CONFIG;
+
+    if (deps.audioContext) {
+      this.chime = createChime(deps.audioContext);
+    }
+
+    this.unsubDurability = this.durabilityHooks.subscribe((event) => {
+      if (event.isHidden) {
+        this.persistToDb();
+      }
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  async initialize(): Promise<SessionState> {
+    const table = this.eventStore.table('activeSession');
+    const existing = await table.get(1) as ActiveSessionRecord | undefined;
+
+    if (!existing) {
+      this.state = 'idle';
+      return this.state;
+    }
+
+    this.record = existing;
+    const staleResult = this.checkStale(existing);
+
+    if (staleResult) {
+      await this.doAbandon(staleResult);
+      return this.state;
+    }
+
+    if (existing.status === 'paused') {
+      this.state = 'paused';
+      this.notify();
+      return this.state;
+    }
+
+    // Active session — check if we need a recovery or walk-away dialog
+    const now = this.now();
+    const startedAt = new Date(existing.startedAt);
+    const elapsedMs = now.getTime() - startedAt.getTime();
+    const plannedMs = existing.plannedMinutes * 60_000;
+
+    if (elapsedMs > plannedMs + WALK_AWAY_THRESHOLD_MS) {
+      this.state = 'walk_away';
+      this.notify();
+      return this.state;
+    }
+
+    // Check if user was away long enough for recovery dialog
+    // We approximate "time away" by looking at how long the page was closed
+    // For tab-close recovery, the caller provides hiddenDuration context
+    this.state = 'active';
+    this.notify();
+    return this.state;
+  }
+
+  async initializeWithRecovery(hiddenDurationMs: number): Promise<SessionState> {
+    const baseState = await this.initialize();
+
+    if (baseState === 'active' && hiddenDurationMs > RECOVERY_THRESHOLD_MS) {
+      this.state = 'recovery';
+      this.notify();
+    }
+
+    return this.state;
+  }
+
+  async start(slotData: SessionSlotData): Promise<void> {
+    if (this.state !== 'idle') {
+      throw new Error(`Cannot start session in state: ${this.state}`);
+    }
+
+    const sessionId = crypto.randomUUID();
+    const startedAt = this.now().toISOString();
+
+    this.record = {
+      id: 1,
+      sessionId,
+      materialId: slotData.materialId,
+      sessionTitle: slotData.sessionTitle,
+      slotDate: slotData.slotDate,
+      weekIndex: slotData.weekIndex,
+      plannedMinutes: slotData.plannedMinutes,
+      startedAt,
+      status: 'active',
+      pauseIntervals: [],
+      pomodoroConfig: this.pomodoroConfig,
+      materialUrl: slotData.materialUrl,
+    };
+
+    await this.persistToDb();
+
+    const payload: SessionStartedPayload = {
+      sessionId,
+      materialId: slotData.materialId,
+      sessionTitle: slotData.sessionTitle,
+      slotDate: slotData.slotDate,
+      weekIndex: slotData.weekIndex,
+      plannedMinutes: slotData.plannedMinutes,
+      startedAt,
+      pomodoroConfig: this.pomodoroConfig,
+    };
+
+    await this.eventStore.append(
+      SESSION_EVENT_KINDS.STARTED,
+      payload as unknown as Record<string, unknown>
+    );
+
+    this.lastPomodoroPhase = 'none';
+    this.state = 'active';
+    this.notify();
+  }
+
+  async pause(): Promise<void> {
+    if (this.state !== 'active' && this.state !== 'walk_away') {
+      throw new Error(`Cannot pause in state: ${this.state}`);
+    }
+
+    if (!this.record) throw new Error('No active session record');
+
+    const pausedAt = this.now().toISOString();
+    this.record.pauseIntervals.push({ pausedAt });
+    this.record.status = 'paused';
+
+    await this.persistToDb();
+
+    const payload: SessionPausedPayload = {
+      sessionId: this.record.sessionId,
+      pausedAt,
+      elapsedActiveMinutes: Math.round(this.getElapsedActiveMs() / 60_000),
+      currentPomodoro: this.getPomodoroPhase().current,
+    };
+
+    await this.eventStore.append(
+      SESSION_EVENT_KINDS.PAUSED,
+      payload as unknown as Record<string, unknown>
+    );
+
+    this.state = 'paused';
+    this.notify();
+  }
+
+  async resume(): Promise<void> {
+    if (this.state !== 'paused') {
+      throw new Error(`Cannot resume in state: ${this.state}`);
+    }
+
+    if (!this.record) throw new Error('No active session record');
+
+    const resumedAt = this.now().toISOString();
+    const lastPause = this.record.pauseIntervals[this.record.pauseIntervals.length - 1];
+    if (lastPause && !lastPause.resumedAt) {
+      lastPause.resumedAt = resumedAt;
+    }
+    this.record.status = 'active';
+
+    await this.persistToDb();
+
+    const payload: SessionResumedPayload = {
+      sessionId: this.record.sessionId,
+      resumedAt,
+    };
+
+    await this.eventStore.append(
+      SESSION_EVENT_KINDS.RESUMED,
+      payload as unknown as Record<string, unknown>
+    );
+
+    this.state = 'active';
+    this.notify();
+  }
+
+  async end(): Promise<void> {
+    if (this.state === 'idle') {
+      throw new Error('No session to end');
+    }
+    if (!this.record) throw new Error('No active session record');
+
+    await this.logSession('completed', this.getElapsedActiveMs());
+  }
+
+  async resolveWalkAway(resolution: WalkAwayResolution): Promise<void> {
+    if (!this.record) throw new Error('No active session record');
+
+    switch (resolution) {
+      case 'log_all':
+        await this.logSession('completed', this.getElapsedActiveMs());
+        break;
+      case 'trim':
+        await this.logSession('trimmed', this.record.plannedMinutes * 60_000);
+        break;
+      case 'discard':
+        await this.doAbandon('discarded');
+        break;
+    }
+  }
+
+  async resolveRecovery(resolution: RecoveryResolution): Promise<void> {
+    if (!this.record) throw new Error('No active session record');
+
+    switch (resolution) {
+      case 'keep_going':
+        this.state = 'active';
+        this.notify();
+        break;
+      case 'end_now':
+        await this.logSession('completed', this.getElapsedActiveMs());
+        break;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // State queries
+  // -----------------------------------------------------------------------
+
+  getState(): SessionState {
+    return this.state;
+  }
+
+  getRecord(): ActiveSessionRecord | null {
+    return this.record;
+  }
+
+  getElapsedActiveMs(): number {
+    if (!this.record) return 0;
+    const now = this.now();
+    const start = new Date(this.record.startedAt).getTime();
+    let totalPauseMs = 0;
+
+    for (const interval of this.record.pauseIntervals) {
+      const pauseStart = new Date(interval.pausedAt).getTime();
+      const pauseEnd = interval.resumedAt
+        ? new Date(interval.resumedAt).getTime()
+        : now.getTime();
+      totalPauseMs += pauseEnd - pauseStart;
+    }
+
+    return Math.max(0, now.getTime() - start - totalPauseMs);
+  }
+
+  getElapsedWallClockMs(): number {
+    if (!this.record) return 0;
+    return this.now().getTime() - new Date(this.record.startedAt).getTime();
+  }
+
+  getPomodoroPhase(): PomodoroPhase {
+    if (!this.record) {
+      return { phase: 'none', current: 0, total: 0, remainingMs: 0 };
+    }
+    return getPomodoroPhase(
+      this.getElapsedWallClockMs(),
+      this.record.plannedMinutes,
+      this.record.pomodoroConfig
+    );
+  }
+
+  isOverrun(): boolean {
+    if (!this.record) return false;
+    return this.getElapsedActiveMs() > this.record.plannedMinutes * 60_000;
+  }
+
+  isWalkAwayDue(): boolean {
+    if (!this.record || this.state !== 'active') return false;
+    const activeMs = this.getElapsedActiveMs();
+    const plannedMs = this.record.plannedMinutes * 60_000;
+    return activeMs > plannedMs + WALK_AWAY_THRESHOLD_MS;
+  }
+
+  /**
+   * Called on each tick to check for Pomodoro phase transitions and play chimes.
+   * Also checks for walk-away threshold.
+   * Returns the current state after any transitions.
+   */
+  tick(): SessionState {
+    if (this.state !== 'active') return this.state;
+
+    // Check Pomodoro transitions for chime
+    const pomo = this.getPomodoroPhase();
+    if (pomo.phase === 'work' && this.lastPomodoroPhase === 'break') {
+      this.chime?.playBreakToWork();
+    } else if (pomo.phase === 'break' && this.lastPomodoroPhase === 'work') {
+      this.chime?.playWorkToBreak();
+    }
+    if (pomo.phase === 'work' || pomo.phase === 'break') {
+      this.lastPomodoroPhase = pomo.phase;
+    }
+
+    // Check walk-away threshold
+    if (this.isWalkAwayDue() && this.state === 'active') {
+      this.state = 'walk_away';
+      this.notify();
+    }
+
+    return this.state;
+  }
+
+  subscribe(listener: SessionLifecycleListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  destroy(): void {
+    this.unsubDurability?.();
+    this.listeners.clear();
+  }
+
+  // -----------------------------------------------------------------------
+  // Internals
+  // -----------------------------------------------------------------------
+
+  private checkStale(record: ActiveSessionRecord): SessionAbandonedPayload['reason'] | null {
+    const now = this.now();
+    const startedAt = new Date(record.startedAt);
+
+    if (record.status === 'paused') {
+      const lastPause = record.pauseIntervals[record.pauseIntervals.length - 1];
+      if (lastPause && !lastPause.resumedAt) {
+        const pausedSince = new Date(lastPause.pausedAt).getTime();
+        if (now.getTime() - pausedSince > STALE_PAUSED_MS) {
+          return 'stale_12h_paused';
+        }
+      }
+      return null;
+    }
+
+    // Active session: check midnight crossing (before 6h — more specific rule)
+    if (startedAt.toDateString() !== now.toDateString()) {
+      return 'stale_midnight';
+    }
+
+    // Active session: check 6h elapsed
+    const elapsedMs = now.getTime() - startedAt.getTime();
+    if (elapsedMs > STALE_ACTIVE_MS) {
+      return 'stale_6h';
+    }
+
+    return null;
+  }
+
+  private async doAbandon(reason: SessionAbandonedPayload['reason']): Promise<void> {
+    if (!this.record) return;
+
+    const activeMinutes = Math.round(this.getElapsedActiveMs() / 60_000);
+
+    const payload: SessionAbandonedPayload = {
+      sessionId: this.record.sessionId,
+      reason,
+      activeMinutesAtAbandon: activeMinutes,
+      abandonedAt: this.now().toISOString(),
+    };
+
+    await this.eventStore.append(
+      SESSION_EVENT_KINDS.ABANDONED,
+      payload as unknown as Record<string, unknown>
+    );
+
+    await this.clearActiveSession();
+    this.state = 'idle';
+    this.notify();
+  }
+
+  private async logSession(resolution: 'completed' | 'trimmed', activeMs: number): Promise<void> {
+    if (!this.record) return;
+
+    const endedAt = this.now().toISOString();
+    const activeMinutes = Math.round(activeMs / 60_000);
+    const totalPauseMs = this.record.pauseIntervals.reduce((sum, p) => {
+      const start = new Date(p.pausedAt).getTime();
+      const end = p.resumedAt ? new Date(p.resumedAt).getTime() : this.now().getTime();
+      return sum + (end - start);
+    }, 0);
+
+    const pomo = this.getPomodoroPhase();
+    const completedPomos = pomo.total > 0
+      ? Math.max(0, (pomo.phase === 'overtime' ? pomo.total : pomo.current - 1))
+      : 0;
+
+    const payload: SessionLoggedPayload = {
+      sessionId: this.record.sessionId,
+      materialId: this.record.materialId,
+      sessionTitle: this.record.sessionTitle,
+      slotDate: this.record.slotDate,
+      weekIndex: this.record.weekIndex,
+      plannedMinutes: this.record.plannedMinutes,
+      startedAt: this.record.startedAt,
+      endedAt,
+      activeMinutes,
+      pauseCount: this.record.pauseIntervals.length,
+      totalPauseMinutes: Math.round(totalPauseMs / 60_000),
+      pomodorosCompleted: completedPomos,
+      source: 'active',
+      resolution,
+      duration: activeMinutes,
+      description: this.record.sessionTitle,
+      date: this.record.slotDate,
+    };
+
+    await this.eventStore.append(
+      SESSION_EVENT_KINDS.LOGGED,
+      payload as unknown as Record<string, unknown>
+    );
+
+    await this.clearActiveSession();
+    this.state = 'idle';
+    this.notify();
+  }
+
+  private async persistToDb(): Promise<void> {
+    if (!this.record) return;
+    try {
+      await this.eventStore.table('activeSession').put(this.record);
+    } catch {
+      // Best-effort persistence — don't crash the session
+    }
+  }
+
+  private async clearActiveSession(): Promise<void> {
+    try {
+      await this.eventStore.table('activeSession').delete(1);
+    } catch {
+      // Best-effort
+    }
+    this.record = null;
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(this.state);
+      } catch {
+        // Listeners should not throw
+      }
+    }
+  }
+}

--- a/apps/app/src/session/chime.ts
+++ b/apps/app/src/session/chime.ts
@@ -1,0 +1,44 @@
+/**
+ * Web Audio API chime for Pomodoro transitions.
+ *
+ * AudioContext must be created from a user gesture (session start click).
+ * Call createChime() once at session start, then playWorkToBreak() and
+ * playBreakToWork() at transitions.
+ */
+
+interface Chime {
+  playWorkToBreak: () => void;
+  playBreakToWork: () => void;
+}
+
+function playTone(ctx: AudioContext, frequency: number, durationMs: number, startDelay = 0): void {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.type = 'sine';
+  osc.frequency.value = frequency;
+
+  gain.gain.setValueAtTime(0.15, ctx.currentTime + startDelay);
+  gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + startDelay + durationMs / 1000);
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+
+  osc.start(ctx.currentTime + startDelay);
+  osc.stop(ctx.currentTime + startDelay + durationMs / 1000);
+}
+
+export function createChime(ctx: AudioContext): Chime {
+  return {
+    playWorkToBreak() {
+      // Descending two-note chime: time to rest
+      playTone(ctx, 659, 300, 0);     // E5
+      playTone(ctx, 523, 400, 0.15);  // C5
+    },
+    playBreakToWork() {
+      // Ascending two-note chime: time to focus
+      playTone(ctx, 523, 300, 0);     // C5
+      playTone(ctx, 659, 400, 0.15);  // E5
+    },
+  };
+}

--- a/apps/app/src/session/components/AbandonedSessionBanner.tsx
+++ b/apps/app/src/session/components/AbandonedSessionBanner.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+
+interface AbandonedSessionBannerProps {
+  activeMinutes: number;
+  onDismiss: () => void;
+}
+
+export function AbandonedSessionBanner({ activeMinutes, onDismiss }: AbandonedSessionBannerProps) {
+  return (
+    <div className="banner attention">
+      <div className="banner-icon-wrap">
+        <svg className="icon" viewBox="0 0 24 24" style={{ width: 16, height: 16 }}>
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      </div>
+      <div className="banner-body">
+        <div className="banner-title">We didn't hear back from your session yesterday</div>
+        <div className="banner-desc">
+          It wasn't logged.
+          {activeMinutes > 0 && (
+            <> You studied ~{activeMinutes} min before we lost you. </>
+          )}
+          <Link to="/log">Log it manually</Link> if you studied.
+        </div>
+      </div>
+      <button className="banner-dismiss" onClick={onDismiss} aria-label="Dismiss">
+        <svg className="icon" viewBox="0 0 24 24" style={{ width: 14, height: 14 }}>
+          <path d="M18 6 6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/apps/app/src/session/components/ComeBackLaterButton.tsx
+++ b/apps/app/src/session/components/ComeBackLaterButton.tsx
@@ -1,0 +1,14 @@
+interface ComeBackLaterButtonProps {
+  onComeBackLater: () => void;
+}
+
+export function ComeBackLaterButton({ onComeBackLater }: ComeBackLaterButtonProps) {
+  return (
+    <button
+      className="btn btn-ghost btn-block session-come-back"
+      onClick={onComeBackLater}
+    >
+      I'll come back later
+    </button>
+  );
+}

--- a/apps/app/src/session/components/EndSessionButton.tsx
+++ b/apps/app/src/session/components/EndSessionButton.tsx
@@ -1,0 +1,16 @@
+interface EndSessionButtonProps {
+  onEnd: () => void;
+  disabled?: boolean;
+}
+
+export function EndSessionButton({ onEnd, disabled }: EndSessionButtonProps) {
+  return (
+    <button
+      className="btn btn-accent btn-block btn-lg session-end-inline"
+      onClick={onEnd}
+      disabled={disabled}
+    >
+      End session
+    </button>
+  );
+}

--- a/apps/app/src/session/components/MaterialStrip.tsx
+++ b/apps/app/src/session/components/MaterialStrip.tsx
@@ -1,0 +1,17 @@
+interface MaterialStripProps {
+  title: string;
+  meta: string;
+  iconLabel?: string;
+}
+
+export function MaterialStrip({ title, meta, iconLabel = 'NB' }: MaterialStripProps) {
+  return (
+    <div className="material-strip">
+      <div className="material-strip-icon">{iconLabel}</div>
+      <div className="material-strip-body">
+        <div className="material-strip-title">{title}</div>
+        <div className="material-strip-meta">{meta}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/session/components/OpenMaterialButton.tsx
+++ b/apps/app/src/session/components/OpenMaterialButton.tsx
@@ -1,0 +1,21 @@
+interface OpenMaterialButtonProps {
+  url: string;
+}
+
+export function OpenMaterialButton({ url }: OpenMaterialButtonProps) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="btn btn-secondary btn-block session-open-material"
+    >
+      <svg className="icon" viewBox="0 0 24 24" style={{ width: 16, height: 16 }}>
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+        <polyline points="15 3 21 3 21 9" />
+        <line x1="10" y1="14" x2="21" y2="3" />
+      </svg>
+      Open material
+    </a>
+  );
+}

--- a/apps/app/src/session/components/PauseResumeButton.tsx
+++ b/apps/app/src/session/components/PauseResumeButton.tsx
@@ -1,0 +1,24 @@
+interface PauseResumeButtonProps {
+  isPaused: boolean;
+  onToggle: () => void;
+}
+
+export function PauseResumeButton({ isPaused, onToggle }: PauseResumeButtonProps) {
+  return (
+    <button className="session-pause-resume" onClick={onToggle}>
+      {isPaused ? (
+        <>
+          <span className="session-pause-icon">▶</span>
+          Resume
+        </>
+      ) : (
+        <>
+          <svg className="icon" viewBox="0 0 24 24" style={{ width: 16, height: 16 }}>
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+          Pause
+        </>
+      )}
+    </button>
+  );
+}

--- a/apps/app/src/session/components/PlannedEndLine.tsx
+++ b/apps/app/src/session/components/PlannedEndLine.tsx
@@ -1,0 +1,25 @@
+interface PlannedEndLineProps {
+  plannedMinutes: number;
+  endsAt: Date;
+  overrun?: boolean;
+}
+
+function formatTimeShort(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+export function PlannedEndLine({ plannedMinutes, endsAt, overrun }: PlannedEndLineProps) {
+  const text = overrun
+    ? `over ${plannedMinutes} min planned · ended ${formatTimeShort(endsAt)}`
+    : `of ${plannedMinutes} min planned · ends ${formatTimeShort(endsAt)}`;
+
+  return (
+    <div className={`session-timer-of${overrun ? ' session-timer-of-overrun' : ''}`}>
+      {text}
+    </div>
+  );
+}

--- a/apps/app/src/session/components/PomodoroIndicator.tsx
+++ b/apps/app/src/session/components/PomodoroIndicator.tsx
@@ -1,0 +1,40 @@
+import type { PomodoroPhase } from '../pomodoro';
+
+interface PomodoroIndicatorProps {
+  phase: PomodoroPhase;
+}
+
+function formatRemaining(ms: number): string {
+  const minutes = Math.ceil(ms / 60_000);
+  return `${minutes} min left`;
+}
+
+export function PomodoroIndicator({ phase }: PomodoroIndicatorProps) {
+  if (phase.phase === 'none') return null;
+
+  let text: string;
+  let colorClass: string;
+
+  switch (phase.phase) {
+    case 'work':
+      text = phase.total > 1
+        ? `Work ${phase.current} of ${phase.total} · ${formatRemaining(phase.remainingMs)}`
+        : `Work · ${formatRemaining(phase.remainingMs)}`;
+      colorClass = 'pomo-work';
+      break;
+    case 'break':
+      text = `Break · ${formatRemaining(phase.remainingMs)}`;
+      colorClass = 'pomo-break';
+      break;
+    case 'overtime':
+      text = 'Great focus — beyond your plan';
+      colorClass = 'pomo-overtime';
+      break;
+  }
+
+  return (
+    <div className={`session-pomo-indicator ${colorClass}`}>
+      {text}
+    </div>
+  );
+}

--- a/apps/app/src/session/components/PulseDot.tsx
+++ b/apps/app/src/session/components/PulseDot.tsx
@@ -1,0 +1,17 @@
+import type { SessionState } from '../types';
+
+interface PulseDotProps {
+  state: SessionState;
+}
+
+const stateClasses: Record<string, string> = {
+  active: 'session-pulse-dot',
+  walk_away: 'session-pulse-dot attention',
+  paused: 'session-pulse-dot paused',
+  recovery: 'session-pulse-dot attention',
+  idle: 'session-pulse-dot paused',
+};
+
+export function PulseDot({ state }: PulseDotProps) {
+  return <span className={stateClasses[state] ?? 'session-pulse-dot'} />;
+}

--- a/apps/app/src/session/components/RecoveryDialog.tsx
+++ b/apps/app/src/session/components/RecoveryDialog.tsx
@@ -1,0 +1,44 @@
+import type { RecoveryResolution } from '../types';
+
+interface RecoveryDialogProps {
+  materialTitle: string;
+  elapsedMinutes: number;
+  awayMinutes: number;
+  onResolve: (resolution: RecoveryResolution) => void;
+}
+
+export function RecoveryDialog({
+  materialTitle,
+  elapsedMinutes,
+  awayMinutes,
+  onResolve,
+}: RecoveryDialogProps) {
+  return (
+    <div className="modal-overlay">
+      <div className="modal-card">
+        <div className="modal-eyebrow">Welcome back</div>
+        <div className="modal-title">You left a session running</div>
+        <div className="modal-body">
+          "{materialTitle}" has been running
+          for <strong>{elapsedMinutes} min</strong>.
+          You were away for about {awayMinutes} minutes.
+        </div>
+
+        <div className="session-recovery-actions">
+          <button
+            className="btn btn-accent btn-block btn-lg"
+            onClick={() => onResolve('keep_going')}
+          >
+            Keep going
+          </button>
+          <button
+            className="btn btn-secondary btn-block"
+            onClick={() => onResolve('end_now')}
+          >
+            End &amp; log {elapsedMinutes} min
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/session/components/SessionEyebrow.tsx
+++ b/apps/app/src/session/components/SessionEyebrow.tsx
@@ -1,0 +1,35 @@
+import type { SessionState } from '../types';
+
+interface SessionEyebrowProps {
+  state: SessionState;
+  weekIndex: number;
+  overrunMinutes?: number;
+  isBreak?: boolean;
+}
+
+export function getEyebrowColorClass(
+  state: SessionState,
+  overrunMinutes: number,
+  isBreak: boolean,
+): string {
+  if (state === 'paused') return 'eyebrow-faint';
+  if (isBreak) return 'eyebrow-clay';
+  if (overrunMinutes > 0) return 'eyebrow-terracotta';
+  return 'eyebrow-moss';
+}
+
+export function SessionEyebrow({ state, weekIndex, overrunMinutes, isBreak }: SessionEyebrowProps) {
+  let text: string;
+
+  if (state === 'paused') {
+    text = `Paused · Week ${weekIndex + 1}`;
+  } else if (isBreak) {
+    text = `On break · Week ${weekIndex + 1}`;
+  } else if (overrunMinutes && overrunMinutes > 0) {
+    text = `${overrunMinutes} min over plan`;
+  } else {
+    text = `In session · Week ${weekIndex + 1}`;
+  }
+
+  return <span>{text}</span>;
+}

--- a/apps/app/src/session/components/SessionFrame.tsx
+++ b/apps/app/src/session/components/SessionFrame.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+interface SessionFrameProps {
+  overrun?: boolean;
+  isBreak?: boolean;
+  isPaused?: boolean;
+  children: ReactNode;
+}
+
+export function SessionFrame({ overrun, isBreak, isPaused, children }: SessionFrameProps) {
+  const className = [
+    'session-frame',
+    overrun && 'is-overrun',
+    isBreak && 'is-break',
+    isPaused && 'is-paused',
+  ].filter(Boolean).join(' ');
+
+  return <div className={className}>{children}</div>;
+}

--- a/apps/app/src/session/components/SessionSubtitle.tsx
+++ b/apps/app/src/session/components/SessionSubtitle.tsx
@@ -1,0 +1,7 @@
+interface SessionSubtitleProps {
+  subtitle: string;
+}
+
+export function SessionSubtitle({ subtitle }: SessionSubtitleProps) {
+  return <div className="session-subtitle">{subtitle}</div>;
+}

--- a/apps/app/src/session/components/SessionTitle.tsx
+++ b/apps/app/src/session/components/SessionTitle.tsx
@@ -1,0 +1,7 @@
+interface SessionTitleProps {
+  title: string;
+}
+
+export function SessionTitle({ title }: SessionTitleProps) {
+  return <div className="session-title">{title}</div>;
+}

--- a/apps/app/src/session/components/TimerDisplay.tsx
+++ b/apps/app/src/session/components/TimerDisplay.tsx
@@ -1,0 +1,30 @@
+interface TimerDisplayProps {
+  elapsedMs: number;
+  overrun?: boolean;
+  large?: boolean;
+}
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(seconds).padStart(2, '0');
+
+  if (hours > 0) {
+    return `${hours}:${mm}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
+}
+
+export function TimerDisplay({ elapsedMs, overrun, large }: TimerDisplayProps) {
+  const className = [
+    'session-timer-time',
+    overrun && 'is-overrun',
+    large && 'session-timer-large',
+  ].filter(Boolean).join(' ');
+
+  return <div className={className}>{formatTime(elapsedMs)}</div>;
+}

--- a/apps/app/src/session/components/WalkAwayDialog.tsx
+++ b/apps/app/src/session/components/WalkAwayDialog.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import type { WalkAwayResolution } from '../types';
+
+interface WalkAwayDialogProps {
+  materialTitle: string;
+  elapsedMinutes: number;
+  startedAtLabel: string;
+  plannedMinutes: number;
+  onResolve: (resolution: WalkAwayResolution) => void;
+}
+
+export function WalkAwayDialog({
+  materialTitle,
+  elapsedMinutes,
+  startedAtLabel,
+  plannedMinutes,
+  onResolve,
+}: WalkAwayDialogProps) {
+  const [selected, setSelected] = useState<WalkAwayResolution>('trim');
+
+  const formatDuration = (min: number) => {
+    const h = Math.floor(min / 60);
+    const m = min % 60;
+    if (h > 0 && m > 0) return `${h}h ${m}m`;
+    if (h > 0) return `${h}h`;
+    return `${m}m`;
+  };
+
+  const buttonLabel = selected === 'log_all'
+    ? `Log ${formatDuration(elapsedMinutes)}`
+    : selected === 'trim'
+      ? `Log ${formatDuration(plannedMinutes)}`
+      : 'Discard session';
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-card">
+        <div className="modal-eyebrow">Welcome back</div>
+        <div className="modal-title">
+          Were you still <em className="modal-title-em">studying</em>?
+        </div>
+        <div className="modal-body">
+          A timer for <strong>{materialTitle}</strong> has been running
+          for <strong>{formatDuration(elapsedMinutes)}</strong> since {startedAtLabel}.
+          That's longer than your usual session — let's get the log right.
+        </div>
+
+        <div className="stack-3">
+          <button
+            className={`choice${selected === 'log_all' ? ' selected' : ''}`}
+            onClick={() => setSelected('log_all')}
+          >
+            <div className="choice-title">Log it as {formatDuration(elapsedMinutes)}</div>
+            <div className="choice-desc">If you actually studied that long today.</div>
+          </button>
+          <button
+            className={`choice${selected === 'trim' ? ' selected' : ''}`}
+            onClick={() => setSelected('trim')}
+          >
+            <div className="choice-title">Trim to planned duration</div>
+            <div className="choice-desc">
+              Most likely — log <strong>{formatDuration(plannedMinutes)}</strong> based
+              on your planned session.
+            </div>
+          </button>
+          <button
+            className={`choice${selected === 'discard' ? ' selected' : ''}`}
+            onClick={() => setSelected('discard')}
+          >
+            <div className="choice-title">Discard the session</div>
+            <div className="choice-desc">If you forgot to end the timer and never came back.</div>
+          </button>
+        </div>
+
+        <button
+          className="btn btn-accent btn-block btn-lg session-walkaway-confirm"
+          onClick={() => onResolve(selected)}
+        >
+          {buttonLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/session/components/index.ts
+++ b/apps/app/src/session/components/index.ts
@@ -1,0 +1,16 @@
+export { PulseDot } from './PulseDot';
+export { SessionEyebrow, getEyebrowColorClass } from './SessionEyebrow';
+export { SessionTitle } from './SessionTitle';
+export { SessionSubtitle } from './SessionSubtitle';
+export { TimerDisplay } from './TimerDisplay';
+export { PomodoroIndicator } from './PomodoroIndicator';
+export { PlannedEndLine } from './PlannedEndLine';
+export { OpenMaterialButton } from './OpenMaterialButton';
+export { MaterialStrip } from './MaterialStrip';
+export { EndSessionButton } from './EndSessionButton';
+export { ComeBackLaterButton } from './ComeBackLaterButton';
+export { PauseResumeButton } from './PauseResumeButton';
+export { SessionFrame } from './SessionFrame';
+export { WalkAwayDialog } from './WalkAwayDialog';
+export { RecoveryDialog } from './RecoveryDialog';
+export { AbandonedSessionBanner } from './AbandonedSessionBanner';

--- a/apps/app/src/session/pomodoro.test.ts
+++ b/apps/app/src/session/pomodoro.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+import { getPomodoroPhase, buildIntervals } from './pomodoro';
+import type { PomodoroConfig } from './types';
+
+const config: PomodoroConfig = { workMinutes: 50, breakMinutes: 10 };
+const min = (m: number) => m * 60_000;
+
+describe('buildIntervals', () => {
+  it('returns empty for slots shorter than one work block', () => {
+    expect(buildIntervals(30, config)).toEqual([]);
+    expect(buildIntervals(45, config)).toEqual([]);
+    expect(buildIntervals(49, config)).toEqual([]);
+  });
+
+  it('60 min = 50 work + 10 break', () => {
+    const intervals = buildIntervals(60, config);
+    expect(intervals).toEqual([
+      { type: 'work', durationMs: min(50) },
+      { type: 'break', durationMs: min(10) },
+    ]);
+  });
+
+  it('90 min = 50 work + 10 break + 30 work', () => {
+    const intervals = buildIntervals(90, config);
+    expect(intervals).toEqual([
+      { type: 'work', durationMs: min(50) },
+      { type: 'break', durationMs: min(10) },
+      { type: 'work', durationMs: min(30) },
+    ]);
+  });
+
+  it('120 min = 2 × (50 work + 10 break)', () => {
+    const intervals = buildIntervals(120, config);
+    expect(intervals).toEqual([
+      { type: 'work', durationMs: min(50) },
+      { type: 'break', durationMs: min(10) },
+      { type: 'work', durationMs: min(50) },
+      { type: 'break', durationMs: min(10) },
+    ]);
+  });
+
+  it('180 min = 3 × (50 work + 10 break)', () => {
+    const intervals = buildIntervals(180, config);
+    expect(intervals).toHaveLength(6);
+    expect(intervals.filter(i => i.type === 'work')).toHaveLength(3);
+    expect(intervals.filter(i => i.type === 'break')).toHaveLength(3);
+  });
+
+  it('150 min = 2 × (50 work + 10 break) + 30 work', () => {
+    const intervals = buildIntervals(150, config);
+    expect(intervals).toEqual([
+      { type: 'work', durationMs: min(50) },
+      { type: 'break', durationMs: min(10) },
+      { type: 'work', durationMs: min(50) },
+      { type: 'break', durationMs: min(10) },
+      { type: 'work', durationMs: min(30) },
+    ]);
+  });
+
+  it('50 min = exactly one work block, no break', () => {
+    const intervals = buildIntervals(50, config);
+    expect(intervals).toEqual([
+      { type: 'work', durationMs: min(50) },
+    ]);
+  });
+});
+
+describe('getPomodoroPhase', () => {
+  describe('no Pomodoro for short slots', () => {
+    it('returns none for 30 min slot', () => {
+      const result = getPomodoroPhase(0, 30, config);
+      expect(result.phase).toBe('none');
+      expect(result.total).toBe(0);
+    });
+
+    it('returns none for 45 min slot', () => {
+      const result = getPomodoroPhase(min(20), 45, config);
+      expect(result.phase).toBe('none');
+    });
+  });
+
+  describe('60 min slot (50 work + 10 break)', () => {
+    it('at 0 min: work block 1, 50 min remaining', () => {
+      const result = getPomodoroPhase(0, 60, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(1);
+      expect(result.total).toBe(1);
+      expect(result.remainingMs).toBe(min(50));
+    });
+
+    it('at 38 min: work block 1, 12 min remaining', () => {
+      const result = getPomodoroPhase(min(38), 60, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(1);
+      expect(result.remainingMs).toBe(min(12));
+    });
+
+    it('at 50 min: break, 10 min remaining', () => {
+      const result = getPomodoroPhase(min(50), 60, config);
+      expect(result.phase).toBe('break');
+      expect(result.current).toBe(1);
+      expect(result.remainingMs).toBe(min(10));
+    });
+
+    it('at 55 min: break, 5 min remaining', () => {
+      const result = getPomodoroPhase(min(55), 60, config);
+      expect(result.phase).toBe('break');
+      expect(result.remainingMs).toBe(min(5));
+    });
+
+    it('at 60 min: overtime', () => {
+      const result = getPomodoroPhase(min(60), 60, config);
+      expect(result.phase).toBe('overtime');
+      expect(result.total).toBe(1);
+    });
+
+    it('at 75 min: still overtime', () => {
+      const result = getPomodoroPhase(min(75), 60, config);
+      expect(result.phase).toBe('overtime');
+    });
+  });
+
+  describe('90 min slot (50 work + 10 break + 30 work)', () => {
+    it('at 0: work 1 of 2', () => {
+      const result = getPomodoroPhase(0, 90, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(1);
+      expect(result.total).toBe(2);
+    });
+
+    it('at 50 min: break', () => {
+      const result = getPomodoroPhase(min(50), 90, config);
+      expect(result.phase).toBe('break');
+    });
+
+    it('at 60 min: work 2 of 2', () => {
+      const result = getPomodoroPhase(min(60), 90, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(2);
+      expect(result.total).toBe(2);
+      expect(result.remainingMs).toBe(min(30));
+    });
+
+    it('at 80 min: work 2, 10 min remaining', () => {
+      const result = getPomodoroPhase(min(80), 90, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(2);
+      expect(result.remainingMs).toBe(min(10));
+    });
+
+    it('at 90 min: overtime', () => {
+      const result = getPomodoroPhase(min(90), 90, config);
+      expect(result.phase).toBe('overtime');
+    });
+  });
+
+  describe('180 min slot (3 × 50/10)', () => {
+    it('at 0: work 1 of 3', () => {
+      const result = getPomodoroPhase(0, 180, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(1);
+      expect(result.total).toBe(3);
+    });
+
+    it('at 110 min: break (second break)', () => {
+      const result = getPomodoroPhase(min(110), 180, config);
+      expect(result.phase).toBe('break');
+      expect(result.current).toBe(2);
+    });
+
+    it('at 120 min: work 3 of 3', () => {
+      const result = getPomodoroPhase(min(120), 180, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(3);
+      expect(result.total).toBe(3);
+    });
+  });
+
+  describe('custom config', () => {
+    const custom: PomodoroConfig = { workMinutes: 25, breakMinutes: 5 };
+
+    it('30 min with 25/5 = work + break', () => {
+      const result = getPomodoroPhase(0, 30, custom);
+      expect(result.phase).toBe('work');
+      expect(result.total).toBe(1);
+    });
+
+    it('at 25 min: break', () => {
+      const result = getPomodoroPhase(min(25), 30, custom);
+      expect(result.phase).toBe('break');
+    });
+  });
+
+  describe('50 min slot = one work block, no break', () => {
+    it('at 0: work 1 of 1', () => {
+      const result = getPomodoroPhase(0, 50, config);
+      expect(result.phase).toBe('work');
+      expect(result.current).toBe(1);
+      expect(result.total).toBe(1);
+      expect(result.remainingMs).toBe(min(50));
+    });
+
+    it('at 50 min: overtime', () => {
+      const result = getPomodoroPhase(min(50), 50, config);
+      expect(result.phase).toBe('overtime');
+    });
+  });
+});

--- a/apps/app/src/session/pomodoro.ts
+++ b/apps/app/src/session/pomodoro.ts
@@ -1,0 +1,96 @@
+import type { PomodoroConfig } from './types';
+
+export interface PomodoroPhase {
+  /** Current phase: work, break, overtime (past planned), or none (slot too short) */
+  phase: 'work' | 'break' | 'overtime' | 'none';
+  /** Current interval number (1-indexed). 0 when phase is 'none' or 'overtime'. */
+  current: number;
+  /** Total number of intervals (work blocks only). 0 when phase is 'none'. */
+  total: number;
+  /** Milliseconds remaining in the current interval. 0 for 'overtime' and 'none'. */
+  remainingMs: number;
+}
+
+/**
+ * Build the interval schedule for a given planned duration and Pomodoro config.
+ * Returns an array of { type, durationMs } entries in order.
+ *
+ * Algorithm:
+ *   1. Full cycles = floor(planned / (work + break))
+ *   2. Remaining = planned - (fullCycles * (work + break))
+ *   3. Each full cycle = work block + break
+ *   4. If remaining > 0, append a final work block of that duration
+ */
+export function buildIntervals(
+  plannedMinutes: number,
+  config: PomodoroConfig
+): Array<{ type: 'work' | 'break'; durationMs: number }> {
+  const workMs = config.workMinutes * 60_000;
+  const breakMs = config.breakMinutes * 60_000;
+  const cycleMs = workMs + breakMs;
+  const plannedMs = plannedMinutes * 60_000;
+
+  if (plannedMs < workMs) return [];
+
+  const fullCycles = Math.floor(plannedMs / cycleMs);
+  const remainingMs = plannedMs - fullCycles * cycleMs;
+
+  const intervals: Array<{ type: 'work' | 'break'; durationMs: number }> = [];
+
+  for (let i = 0; i < fullCycles; i++) {
+    intervals.push({ type: 'work', durationMs: workMs });
+    intervals.push({ type: 'break', durationMs: breakMs });
+  }
+
+  if (remainingMs > 0) {
+    intervals.push({ type: 'work', durationMs: remainingMs });
+  }
+
+  return intervals;
+}
+
+/**
+ * Compute the current Pomodoro phase given wall-clock elapsed time.
+ *
+ * Wall-clock based: elapsed is measured from session start, ignoring pauses.
+ * This means the Pomodoro phase advances even while the user is paused.
+ */
+export function getPomodoroPhase(
+  elapsedMs: number,
+  plannedMinutes: number,
+  config: PomodoroConfig
+): PomodoroPhase {
+  const intervals = buildIntervals(plannedMinutes, config);
+
+  if (intervals.length === 0) {
+    return { phase: 'none', current: 0, total: 0, remainingMs: 0 };
+  }
+
+  const totalWorkBlocks = intervals.filter(i => i.type === 'work').length;
+
+  if (elapsedMs >= plannedMinutes * 60_000) {
+    return { phase: 'overtime', current: 0, total: totalWorkBlocks, remainingMs: 0 };
+  }
+
+  let accumulated = 0;
+  let workBlockIndex = 0;
+
+  for (const interval of intervals) {
+    if (interval.type === 'work') workBlockIndex++;
+    const end = accumulated + interval.durationMs;
+
+    if (elapsedMs < end) {
+      const remainingMs = end - elapsedMs;
+      return {
+        phase: interval.type,
+        current: workBlockIndex,
+        total: totalWorkBlocks,
+        remainingMs,
+      };
+    }
+
+    accumulated = end;
+  }
+
+  return { phase: 'overtime', current: 0, total: totalWorkBlocks, remainingMs: 0 };
+}

--- a/apps/app/src/session/session.css
+++ b/apps/app/src/session/session.css
@@ -1,0 +1,334 @@
+/* =================================================================
+   /study/session — active session
+   Marginalia v1.0
+   ================================================================= */
+
+/* ---------------- Page shell ---------------- */
+.session-layout {
+  max-width: var(--container-narrow);     /* 640px on mobile/tablet */
+  margin: 0 auto;
+  padding: 20px 20px 96px;                /* extra bottom for desktop FAB */
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.session-layout-centered {
+  justify-content: center;
+}
+
+/* ---------------- Top bar — pause + sync ---------------- */
+.session-top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-5);
+}
+
+.session-pause-resume {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 6px 8px;
+  margin-left: -8px;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.session-pause-resume:hover {
+  background: var(--paper-deep);
+  color: var(--text-primary);
+}
+.session-pause-icon {
+  font-size: 11px;
+  line-height: 1;
+}
+
+/* ---------------- Session frame card ---------------- */
+.session-frame {
+  background: var(--surface-page);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+}
+.session-frame.is-overrun  { border-color: var(--terracotta); }
+.session-frame.is-break,
+.session-frame-break       { background: rgba(194, 142, 90, 0.05); }
+
+/* Paused state — timer is asleep, material still visible */
+.session-frame.is-paused {
+  background: var(--paper-deep);
+  border-color: var(--border-subtle);
+  transition:
+    background-color var(--duration-3) var(--ease-out),
+    border-color var(--duration-3) var(--ease-out);
+}
+
+.session-frame.is-paused .session-timer-time {
+  color: var(--text-secondary);
+  transition: color var(--duration-3) var(--ease-out);
+}
+
+.session-frame.is-paused .session-pomo-indicator,
+.session-frame.is-paused .session-pomo-indicator.pomo-work,
+.session-frame.is-paused .session-pomo-indicator.pomo-break,
+.session-frame.is-paused .session-pomo-indicator.pomo-overtime {
+  color: var(--text-tertiary);
+}
+
+.session-frame.is-paused .session-timer-of {
+  color: var(--text-tertiary);
+}
+
+/* ---------------- Eyebrow with pulse dot ---------------- */
+.session-eyebrow-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  line-height: 1;
+}
+.eyebrow-moss        { color: var(--moss); }
+.eyebrow-clay        { color: var(--clay); }
+.eyebrow-terracotta  { color: var(--terracotta); }
+.eyebrow-faint       { color: var(--ink-faint); }
+
+.session-pulse-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--moss);
+  animation: session-pulse 2s ease-in-out infinite;
+  flex-shrink: 0;
+}
+.session-pulse-dot.attention { background: var(--terracotta); }
+.session-pulse-dot.break     { background: var(--clay); animation-duration: 3s; }
+.session-pulse-dot.paused    { background: var(--ink-faint); animation: none; }
+
+@keyframes session-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .session-pulse-dot { animation: none; }
+}
+
+/* ---------------- Title + subtitle — centered, Fraunces ---------------- */
+.session-title {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.012em;
+  line-height: 1.2;
+  text-align: center;
+  text-wrap: balance;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.session-subtitle {
+  font-size: 13px;
+  text-align: center;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-5);
+}
+
+/* ---------------- Timer display ---------------- */
+.session-timer-display {
+  text-align: center;
+  margin-bottom: var(--space-5);
+}
+.session-timer-time {
+  font-family: var(--font-display);
+  font-size: 56px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  font-variation-settings: 'opsz' 144;
+  font-feature-settings: 'tnum';
+  line-height: 1;
+  color: var(--text-primary);
+}
+.session-timer-time.is-overrun { color: var(--terracotta); }
+
+.session-timer-large           { font-size: 72px; }
+
+.session-timer-of {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  margin-top: var(--space-2);
+}
+.session-timer-of-overrun { color: var(--terracotta-d); }
+
+/* ---------------- Pomodoro work/break indicator ---------------- */
+.session-pomo-indicator {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  text-align: center;
+  margin-top: var(--space-3);
+}
+.pomo-work     { color: var(--moss); }
+.pomo-break    { color: var(--clay); }
+.pomo-overtime { color: var(--terracotta); }
+
+/* ---------------- Material strip ---------------- */
+.material-strip {
+  background: var(--surface-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.material-strip-icon {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--paper-deep);
+  color: var(--rust);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+}
+.material-strip-body { flex: 1; min-width: 0; }
+.material-strip-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.3;
+  margin-bottom: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.material-strip-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+}
+
+/* Open material affordance */
+.session-open-material {
+  margin-top: var(--space-3);
+  width: 100%;
+}
+
+/* ---------------- Action buttons ---------------- */
+.session-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-5);
+}
+.session-actions .btn { width: 100%; }
+.session-come-back     { color: var(--text-tertiary); }
+
+/* Desktop FAB — hidden on mobile, swapped in on desktop */
+.session-fab-end { display: none; }
+
+/* ---------------- Banners ---------------- */
+.banner-dismiss {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: var(--radius-sm);
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  align-self: flex-start;
+}
+.banner-dismiss:hover {
+  background: var(--paper-deep);
+  color: var(--text-primary);
+}
+
+/* ---------------- Modal helpers ---------------- */
+.modal-title-em {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--terracotta);
+}
+.session-recovery-actions,
+.session-walkaway-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+/* ---------------- Empty state ---------------- */
+.session-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  text-align: center;
+  padding: var(--space-8) var(--space-5);
+  gap: var(--space-4);
+}
+.session-empty p {
+  color: var(--text-secondary);
+  max-width: 260px;
+}
+
+/* =================================================================
+   Desktop — 1024px and up
+   Same vertical shape, wider type, FAB instead of inline End button.
+   ================================================================= */
+@media (min-width: 1024px) {
+  .session-layout {
+    max-width: 720px;
+    padding: var(--space-7) var(--space-6) var(--space-9);
+  }
+
+  .session-frame {
+    padding: var(--space-6) var(--space-7);
+  }
+
+  .session-title       { font-size: 26px; }
+  .session-subtitle    { font-size: 14px; margin-bottom: var(--space-6); }
+
+  .session-timer-time  { font-size: 96px; }
+  .session-timer-large { font-size: 120px; }
+
+  /* Hide inline End on desktop — the FAB takes over */
+  .session-end-inline { display: none; }
+
+  .session-fab-end {
+    display: block;
+    position: fixed;
+    right: var(--space-6);
+    bottom: var(--space-6);
+    z-index: 10;
+  }
+  .session-fab-end .btn {
+    box-shadow: var(--shadow-md);
+    padding: 14px 28px;
+    font-size: 15px;
+  }
+}

--- a/apps/app/src/session/types.ts
+++ b/apps/app/src/session/types.ts
@@ -1,0 +1,281 @@
+/**
+ * Session lifecycle types for Study Tracker.
+ *
+ * Five event kinds flow through the sync pipeline:
+ *   SessionStarted  → user begins a study session
+ *   SessionPaused   → user pauses (clock stops, Pomodoro keeps ticking)
+ *   SessionResumed  → user resumes from pause
+ *   SessionLogged   → session ends with logged study time (also used by manual /log form)
+ *   SessionAbandoned → session closes without logged time (discard or stale)
+ *
+ * An "unresolved" session is a SessionStarted with no matching SessionLogged
+ * or SessionAbandoned (matched by sessionId). Cross-device sync uses this to
+ * detect active sessions on other devices.
+ *
+ * Pomodoro intervals are wall-clock based (computed from startedAt, ignoring
+ * pause intervals). This means break/work phase advances even while paused.
+ * On overtime (elapsed > planned), Pomodoro stops cycling.
+ *
+ * Downstream consumers:
+ *   - ProgressEngine (issue 009): reads duration, activeMinutes, source
+ *   - PaceCalibration (issue 009): reads activeMinutes, plannedMinutes, source
+ *   - WeeklyNarrative (issue 011): reads pomodorosCompleted, pauseCount, resolution
+ *   - SyncEngine: pushes/pulls all event kinds through public.events table
+ */
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+/** UUID linking all lifecycle events for a single session */
+export type SessionId = string;
+
+/** Pomodoro timer configuration snapshotted at session start */
+export interface PomodoroConfig {
+  /** Duration of a work interval in minutes (default: 50) */
+  workMinutes: number;
+  /** Duration of a break interval in minutes (default: 10) */
+  breakMinutes: number;
+}
+
+export const DEFAULT_POMODORO_CONFIG: PomodoroConfig = {
+  workMinutes: 50,
+  breakMinutes: 10,
+};
+
+// ---------------------------------------------------------------------------
+// Event payloads
+// ---------------------------------------------------------------------------
+
+/**
+ * Emitted when the user starts a session from the up-next card.
+ * One per session — the sessionId is generated here and used by all
+ * subsequent events for this session.
+ */
+export interface SessionStartedPayload {
+  sessionId: SessionId;
+  /** Which material from the roadmap */
+  materialId: string;
+  /** Display title shown in the session UI */
+  sessionTitle: string;
+  /** ISO date (YYYY-MM-DD) — the scheduled date of the slot in the roadmap */
+  slotDate: string;
+  /** Which week in the roadmap (0-indexed) */
+  weekIndex: number;
+  /** How long the slot was planned for, in minutes */
+  plannedMinutes: number;
+  /** ISO timestamp — when the user tapped "Start session" */
+  startedAt: string;
+  /**
+   * Snapshot of Pomodoro config at session start.
+   * Stored here so historical data remains accurate even if the user
+   * changes their Pomodoro settings later (via PreferenceSet, issue 015).
+   */
+  pomodoroConfig: PomodoroConfig;
+}
+
+/**
+ * Emitted when the user taps Pause (clock stops).
+ * The Pomodoro timer continues on wall-clock time — only the study
+ * clock and activeMinutes tracking are affected by pause.
+ */
+export interface SessionPausedPayload {
+  sessionId: SessionId;
+  /** ISO timestamp — when the user paused */
+  pausedAt: string;
+  /** Total non-paused study minutes accumulated at the moment of pause */
+  elapsedActiveMinutes: number;
+  /** Which Pomodoro work block the user was on (1-indexed). 0 if no Pomodoro. */
+  currentPomodoro: number;
+}
+
+/**
+ * Emitted when the user resumes from pause.
+ */
+export interface SessionResumedPayload {
+  sessionId: SessionId;
+  /** ISO timestamp — when the user tapped Resume */
+  resumedAt: string;
+}
+
+/**
+ * Emitted when a session ends with logged study time.
+ *
+ * Backward-compatible with the manual /log form: the `duration`,
+ * `description`, and `date` fields are always present regardless of source.
+ * Active sessions populate the extended fields; manual logs leave them
+ * undefined.
+ *
+ * `source` distinguishes the two paths so downstream consumers
+ * (PaceCalibration, WeeklyNarrative) can weight them differently.
+ */
+export interface SessionLoggedPayload {
+  // --- Active session fields (undefined for manual logs) ---
+  /** UUID linking to SessionStarted */
+  sessionId?: SessionId;
+  materialId?: string;
+  sessionTitle?: string;
+  /** ISO date — the scheduled slot date */
+  slotDate?: string;
+  weekIndex?: number;
+  /** The slot's planned duration in minutes */
+  plannedMinutes?: number;
+  /** ISO timestamp — when the session started */
+  startedAt?: string;
+  /** ISO timestamp — when the user tapped End */
+  endedAt?: string;
+  /** Total non-paused study time in minutes */
+  activeMinutes?: number;
+  /** Number of times the user paused during this session */
+  pauseCount?: number;
+  /** Total minutes spent in paused state */
+  totalPauseMinutes?: number;
+  /** Number of full Pomodoro work intervals completed */
+  pomodorosCompleted?: number;
+  /** How the session ended — 'completed' (normal End tap) or 'trimmed' (walk-away trim) */
+  resolution?: 'completed' | 'trimmed';
+
+  // --- Always-present fields (backward compat) ---
+  /**
+   * 'active' = logged from the live session timer
+   * 'manual' = logged from the /log past-session form
+   * Defaults to 'manual' for existing events without this field.
+   */
+  source: 'active' | 'manual';
+  /** Study duration in minutes. = activeMinutes for active sessions. */
+  duration: number;
+  /** Session description. = sessionTitle for active sessions. */
+  description: string;
+  /** ISO date (YYYY-MM-DD). = slotDate for active sessions. */
+  date: string;
+}
+
+/**
+ * Emitted to close out a SessionStarted without logging study time.
+ *
+ * Reasons:
+ *   'discarded'       — user chose "Discard" in the walk-away dialog
+ *   'stale_6h'        — active session exceeded 6 hours of elapsed time
+ *   'stale_midnight'  — active session crossed a calendar date boundary
+ *   'stale_12h_paused' — paused session exceeded 12 hours of continuous pause
+ *
+ * `activeMinutesAtAbandon` is shown in the Home banner so the user
+ * can decide whether to manually log the time via /log.
+ */
+export interface SessionAbandonedPayload {
+  sessionId: SessionId;
+  reason: 'discarded' | 'stale_6h' | 'stale_midnight' | 'stale_12h_paused';
+  /** How many active (non-paused) minutes were accumulated before abandonment */
+  activeMinutesAtAbandon: number;
+  /** ISO timestamp — when the session was abandoned */
+  abandonedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Event kind constants
+// ---------------------------------------------------------------------------
+
+export const SESSION_EVENT_KINDS = {
+  STARTED: 'SessionStarted',
+  PAUSED: 'SessionPaused',
+  RESUMED: 'SessionResumed',
+  LOGGED: 'SessionLogged',
+  ABANDONED: 'SessionAbandoned',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Local persistence — Dexie activeSession table
+// ---------------------------------------------------------------------------
+
+/** A single pause interval with start and optional end */
+export interface PauseInterval {
+  /** ISO timestamp — when the pause began */
+  pausedAt: string;
+  /** ISO timestamp — when the pause ended (undefined if still paused) */
+  resumedAt?: string;
+}
+
+/**
+ * Shape stored in the Dexie `activeSession` table as a singleton (id=1).
+ *
+ * Written on every state change and on page-close (via DurabilityHooks).
+ * Read on app launch to detect and recover in-progress sessions.
+ *
+ * This record is the local source of truth for the session UI.
+ * It is NOT synced to Supabase directly — instead, the lifecycle events
+ * (SessionStarted, SessionPaused, etc.) flow through the sync pipeline,
+ * and remote devices reconstruct the active session from those events.
+ */
+export interface ActiveSessionRecord {
+  /** Always 1 — singleton row */
+  id: 1;
+  /** UUID linking to the lifecycle events */
+  sessionId: SessionId;
+  /** Material being studied */
+  materialId: string;
+  /** Display title */
+  sessionTitle: string;
+  /** ISO date — scheduled slot date */
+  slotDate: string;
+  /** Roadmap week (0-indexed) */
+  weekIndex: number;
+  /** Planned duration in minutes */
+  plannedMinutes: number;
+  /** ISO timestamp — when the session started */
+  startedAt: string;
+  /** Current session state */
+  status: 'active' | 'paused';
+  /** Complete history of pause/resume intervals for accurate time accounting */
+  pauseIntervals: PauseInterval[];
+  /** Pomodoro config snapshotted at session start */
+  pomodoroConfig: PomodoroConfig;
+  /** Optional URL for "Open material" button */
+  materialUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// SessionLifecycle state machine
+// ---------------------------------------------------------------------------
+
+/**
+ * UI-facing session states:
+ *   idle      — no active session
+ *   active    — timer running (work or break Pomodoro phase)
+ *   paused    — timer frozen, user tapped Pause
+ *   walk_away — elapsed > planned + 10 min, dialog shown
+ *   recovery  — tab reopened after > 5 min away, dialog shown
+ */
+export type SessionState = 'idle' | 'active' | 'paused' | 'walk_away' | 'recovery';
+
+/**
+ * Walk-away dialog resolution choices.
+ *   log_all  — log the entire elapsed time
+ *   trim     — log only the planned duration
+ *   discard  — abandon the session, log nothing
+ */
+export type WalkAwayResolution = 'log_all' | 'trim' | 'discard';
+
+/**
+ * Recovery dialog resolution choices.
+ *   keep_going — resume the session
+ *   end_now    — end and log active time accumulated before the user left
+ */
+export type RecoveryResolution = 'keep_going' | 'end_now';
+
+// ---------------------------------------------------------------------------
+// Slot data passed via React Router location state
+// ---------------------------------------------------------------------------
+
+/**
+ * Data passed from the Home up-next card to /session via location.state.
+ * Contains everything needed to start a session without additional queries.
+ */
+export interface SessionSlotData {
+  materialId: string;
+  sessionTitle: string;
+  slotDate: string;
+  weekIndex: number;
+  plannedMinutes: number;
+  materialUrl?: string;
+  role?: 'anchor' | 'foundation' | 'practice';
+}

--- a/apps/app/src/sync/SyncEngine.test.ts
+++ b/apps/app/src/sync/SyncEngine.test.ts
@@ -168,7 +168,8 @@ function createEventStore(userId: string): { db: Dexie; eventStore: EventStore }
   db.version(1).stores({
     events: '++id, kind, createdAt',
     sync_queue: '++id, kind, createdAt, retries',
-    sync_meta: 'key'
+    sync_meta: 'key',
+    activeSession: 'id',
   });
   return { db, eventStore: new EventStore(db) };
 }

--- a/apps/app/src/sync/SyncEngine.ts
+++ b/apps/app/src/sync/SyncEngine.ts
@@ -292,6 +292,8 @@ export class SyncEngine {
             createdAt: e.created_at,
           }))
         );
+
+        await this.reconcileSessionState(foreignEvents);
       }
 
       // Advance cursor even for own-client events so we don't re-fetch them.
@@ -538,6 +540,63 @@ export class SyncEngine {
 
   private async setLastPulledId(id: number): Promise<void> {
     await this.eventStore.table('sync_meta').put({ key: 'lastPulledId', value: id });
+  }
+
+  // ─── Session state reconciliation ─────────────────────────────────────────
+
+  private async reconcileSessionState(
+    foreignEvents: Array<{
+      kind: string;
+      payload: Record<string, unknown>;
+    }>
+  ): Promise<void> {
+    const sessionTable = this.eventStore.table('activeSession');
+
+    for (const event of foreignEvents) {
+      switch (event.kind) {
+        case 'SessionStarted': {
+          const existing = await sessionTable.get(1);
+          if (!existing) {
+            await sessionTable.put({
+              id: 1,
+              sessionId: event.payload.sessionId,
+              materialId: event.payload.materialId,
+              sessionTitle: event.payload.sessionTitle,
+              slotDate: event.payload.slotDate,
+              weekIndex: event.payload.weekIndex,
+              plannedMinutes: event.payload.plannedMinutes,
+              startedAt: event.payload.startedAt,
+              status: 'active',
+              pauseIntervals: [],
+              pomodoroConfig: event.payload.pomodoroConfig ?? { workMinutes: 50, breakMinutes: 10 },
+            });
+          }
+          break;
+        }
+        case 'SessionPaused': {
+          const current = await sessionTable.get(1);
+          if (current && current.sessionId === event.payload.sessionId) {
+            await sessionTable.update(1, { status: 'paused' });
+          }
+          break;
+        }
+        case 'SessionResumed': {
+          const current = await sessionTable.get(1);
+          if (current && current.sessionId === event.payload.sessionId) {
+            await sessionTable.update(1, { status: 'active' });
+          }
+          break;
+        }
+        case 'SessionLogged':
+        case 'SessionAbandoned': {
+          const current = await sessionTable.get(1);
+          if (current && current.sessionId === event.payload.sessionId) {
+            await sessionTable.delete(1);
+          }
+          break;
+        }
+      }
+    }
   }
 
   // ─── Public controls ──────────────────────────────────────────────────────

--- a/apps/app/src/sync/SyncProvider.tsx
+++ b/apps/app/src/sync/SyncProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useRef, useState, type ReactNode 
 import { SyncEngine } from './SyncEngine';
 import type { SupabaseClientLike, SyncState } from './types';
 import type { EventStore } from '../events/EventStore';
+import { DurabilityHooks } from '../lib/DurabilityHooks';
 
 const DEFAULT_OPTIONS = {
   visibilityIdleThresholdMs: 5 * 60 * 1000,
@@ -61,7 +62,7 @@ export function SyncProvider({ children, supabase, supabaseUrl, userId, eventSto
   const clientIdRef = useRef<string>(getOrCreateClientId());
   const lastUserIdRef = useRef<string | null>(null);
   const lastEventStoreRef = useRef<EventStore | null>(null);
-  const hiddenTimeRef = useRef<number>(0);
+  const durabilityRef = useRef<DurabilityHooks | null>(null);
 
   useEffect(() => {
     if (lastUserIdRef.current && lastUserIdRef.current !== userId) {
@@ -103,26 +104,21 @@ export function SyncProvider({ children, supabase, supabaseUrl, userId, eventSto
   }, [supabase, userId, eventStore]);
 
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        hiddenTimeRef.current = Date.now();
-      } else {
-        const hiddenDuration = Date.now() - hiddenTimeRef.current;
-        engineRef.current?.handleVisibilityChange(true, hiddenDuration).catch(() => {});
-        hiddenTimeRef.current = 0;
+    const hooks = new DurabilityHooks();
+    durabilityRef.current = hooks;
+
+    const unsub = hooks.subscribe((event) => {
+      if (event.type === 'visibilitychange' && !event.isHidden) {
+        engineRef.current?.handleVisibilityChange(true, event.hiddenDurationMs).catch(() => {});
+      } else if (event.type === 'pagehide') {
+        engineRef.current?.flushOnPageHide().catch(() => {});
       }
-    };
-
-    const handlePageHide = () => {
-      engineRef.current?.flushOnPageHide().catch(() => {});
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('pagehide', handlePageHide);
+    });
 
     return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('pagehide', handlePageHide);
+      unsub();
+      hooks.destroy();
+      durabilityRef.current = null;
     };
   }, []);
 

--- a/packages/design-tokens/src/components.css
+++ b/packages/design-tokens/src/components.css
@@ -26,6 +26,7 @@
   -webkit-user-select: none;
   line-height: 1;
 }
+.btn:hover { color: inherit; }
 .btn:active:not(:disabled) { transform: translateY(1px); }
 .btn:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
 .btn:disabled { opacity: 0.4; cursor: not-allowed; transform: none; }


### PR DESCRIPTION
## Summary
- Add Session page (`/session`) with timer, pause/resume, complete, and abandon flows
- Add `activeSession` table to EventStore for local timer state persistence
- Add `DurabilityHooks` replacing inline visibility/pagehide handlers in SyncProvider
- `SyncEngine.reconcileSessionState` reconciles remote session events (started/paused/resumed/logged/abandoned)
- Home dashboard shows "In progress" card for active sessions and "AbandonedSessionBanner" for abandoned sessions
- NavBar gains Session icon with new route `/session`

## Testing
- `pnpm --filter app test` — Vitest unit tests
- `pnpm test:e2e` — Playwright smoke tests